### PR TITLE
Add entrypoint shell file for use with Docker Compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+docker-image:
+	docker image build -t cashu:0.4.2 .

--- a/build_env.py
+++ b/build_env.py
@@ -1,0 +1,41 @@
+import os
+from pathlib import Path
+import requests
+
+LNBITS_ENDPOINT = "Not found"
+LNBITS_ENDPOINT_LOCAL = "http://127.0.0.1:5001"
+LNBITS_ENDPOINT_DOCKER = "http://lnbits:5001"
+ENV_FILE = os.path.join(str(Path.home()), ".cashu", ".env")
+
+print("Creating wallet and fetching admin key")
+
+res = None
+try:
+    res = requests.get(f"{LNBITS_ENDPOINT_LOCAL}/wallet?nme=12345678")
+    LNBITS_ENDPOINT = LNBITS_ENDPOINT_LOCAL
+except:
+    pass
+
+if res is None:
+    try:
+        res = requests.get(f"{LNBITS_ENDPOINT_DOCKER}/wallet?nme=12345678")
+        LNBITS_ENDPOINT = LNBITS_ENDPOINT_DOCKER
+    except:
+        pass
+
+if res is None:
+    raise Exception("Could not connect to lnbits")
+
+admin_key = res.text.split('adminkey": "')[1].split('", "balance_msat"')[0]
+user = res.text.split('"user": "')[1].split('"}]};')[0]
+
+print(f"Admin key: {admin_key}")
+print(f"User id: {user}")
+
+e = open(ENV_FILE, "w")
+e.write(f"LNBITS_ENDPOINT={LNBITS_ENDPOINT}\n")
+e.write(f"LNBITS_KEY={admin_key}\n")
+e.write(f"# user={user}")
+e.close()
+
+print("wrote .env file")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+python build_env.py
+
+poetry run mint --port 3338 --host 0.0.0.0


### PR DESCRIPTION
This draft PR adds an entry point file to so this image can be more easily used from within a docker-compose environment.

The `build_env.py` file is run when the Docker container is started. Its sole purpose is to create a LNbits wallet and fetch the admin key. It'll populate the `.env` file with the fetched data. *This file should probably be in a subfolder or somewhere.*

Example for legend-regtest: 
https://github.com/fusion44/legend-regtest-enviroment/blob/main/docker-compose.yml
(use make docker-image before starting the evironment)