### PR TITLE
default unix timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ cashu info
 
 Returns:
 ```bash
-Version: 0.5.2
+Version: 0.5.3
 Debug: False
 Cashu dir: /home/user/.cashu
 Wallet: wallet

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -53,4 +53,4 @@ LNBITS_ENDPOINT = env.str("LNBITS_ENDPOINT", default=None)
 LNBITS_KEY = env.str("LNBITS_KEY", default=None)
 
 MAX_ORDER = 64
-VERSION = "0.5.2"
+VERSION = "0.5.3"

--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -1,3 +1,4 @@
+import time
 from typing import Any, List, Optional
 
 from cashu.core.base import Invoice, MintKeyset, Proof
@@ -168,9 +169,9 @@ async def store_keyset(
         (
             keyset.id,
             keyset.derivation_path,
-            keyset.valid_from or db.timestamp_now,
-            keyset.valid_to or db.timestamp_now,
-            keyset.first_seen or db.timestamp_now,
+            keyset.valid_from or int(time.time()),
+            keyset.valid_to or int(time.time()),
+            keyset.first_seen or int(time.time()),
             True,
             keyset.version,
         ),

--- a/cashu/wallet/crud.py
+++ b/cashu/wallet/crud.py
@@ -198,9 +198,9 @@ async def store_keyset(
         (
             keyset.id,
             mint_url or keyset.mint_url,
-            keyset.valid_from,
-            keyset.valid_to,
-            keyset.first_seen,
+            keyset.valid_from or int(time.time()),
+            keyset.valid_to or int(time.time()),
+            keyset.first_seen or int(time.time()),
             True,
         ),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cashu"
-version = "0.5.2"
+version = "0.5.3"
 description = "Ecash wallet and mint."
 authors = ["calle <callebtc@protonmail.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ entry_points = {"console_scripts": ["cashu = cashu.wallet.cli:cli"]}
 
 setuptools.setup(
     name="cashu",
-    version="0.5.2",
+    version="0.5.3",
     description="Ecash wallet and mint with Bitcoin Lightning support",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The default timestamps for keysets are fixed. Before, it was wrongly using the plain SQLite syntax, but now it actually writes the unix timestamp as an int (for SQLite compatibility).