### PR TITLE
Mint/keyset_autosave

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ cashu info
 
 Returns:
 ```bash
-Version: 0.5.3
+Version: 0.5.4
 Debug: False
 Cashu dir: /home/user/.cashu
 Wallet: wallet

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -53,4 +53,4 @@ LNBITS_ENDPOINT = env.str("LNBITS_ENDPOINT", default=None)
 LNBITS_KEY = env.str("LNBITS_KEY", default=None)
 
 MAX_ORDER = 64
-VERSION = "0.5.3"
+VERSION = "0.5.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cashu"
-version = "0.5.3"
+version = "0.5.4"
 description = "Ecash wallet and mint."
 authors = ["calle <callebtc@protonmail.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ entry_points = {"console_scripts": ["cashu = cashu.wallet.cli:cli"]}
 
 setuptools.setup(
     name="cashu",
-    version="0.5.3",
+    version="0.5.4",
     description="Ecash wallet and mint with Bitcoin Lightning support",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Option to use `autosave=True` (default) in `ledger.init_keysets()` to turn on and off whether the active keyset should be stored upon startup. 

Useful for multimint apps like LNbits where you don't have an "active keyset".