### PR TITLE
Fix/tokenv2mints

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ cashu info
 
 Returns:
 ```bash
-Version: 0.8.2
+Version: 0.8.3
 Debug: False
 Cashu dir: /home/user/.cashu
 Wallet: wallet

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -57,4 +57,4 @@ NOSTR_PRIVATE_KEY = env.str("NOSTR_PRIVATE_KEY", default=None)
 NOSTR_RELAYS = env.list("NOSTR_RELAYS", default=["wss://nostr-pub.wellorder.net"])
 
 MAX_ORDER = 64
-VERSION = "0.8.2"
+VERSION = "0.8.3"

--- a/cashu/wallet/cli.py
+++ b/cashu/wallet/cli.py
@@ -7,7 +7,6 @@ import os
 import sys
 import threading
 import time
-import urllib.parse
 from datetime import datetime
 from functools import wraps
 from itertools import groupby
@@ -19,7 +18,7 @@ from typing import Dict, List
 import click
 from loguru import logger
 
-from cashu.core.base import Proof
+from cashu.core.base import Proof, TokenV2
 from cashu.core.helpers import sum_proofs
 from cashu.core.migrations import migrate_databases
 from cashu.core.settings import (
@@ -51,7 +50,7 @@ from cashu.wallet.wallet import Wallet as Wallet
 from .clihelpers import (
     get_mint_wallet,
     print_mint_balances,
-    proofs_to_token,
+    proofs_to_serialized_tokenv2,
     redeem_multimint,
     token_from_lnbits_link,
     verify_mints,
@@ -379,7 +378,7 @@ async def receive(ctx, token: str, lock: str):
         proofs = [Proof(**p) for p in json.loads(base64.urlsafe_b64decode(token))]
 
         # we take the proofs parsed from the old format token and produce a new format token with it
-        token = await proofs_to_token(wallet, proofs, url)
+        token = await proofs_to_serialized_tokenv2(wallet, proofs, url)
     except:
         pass
 
@@ -398,8 +397,9 @@ async def receive(ctx, token: str, lock: str):
         for m in dtoken["mints"]:
             m["ids"] = m.pop("ks")
 
-    assert "proofs" in dtoken, Exception("no proofs in token")
-    includes_mint_info: bool = "mints" in dtoken and dtoken.get("mints") is not None
+    tokenObj = TokenV2.parse_obj(dtoken)
+    assert len(tokenObj.proofs), Exception("no proofs in token")
+    includes_mint_info: bool = tokenObj.mints is not None and len(tokenObj.mints) > 0
 
     # if there is a `mints` field in the token
     # we check whether the token has mints that we don't know yet

--- a/cashu/wallet/cli.py
+++ b/cashu/wallet/cli.py
@@ -392,9 +392,11 @@ async def receive(ctx, token: str, lock: str):
     if "tokens" in dtoken:
         dtoken["proofs"] = dtoken.pop("tokens")
 
-    # backwards compatibility wallet to wallet < 0.8.3: V2 tokens got rid of the "MINT_NAME" key in "mints"
+    # backwards compatibility wallet to wallet < 0.8.3: V2 tokens got rid of the "MINT_NAME" key in "mints" and renamed "ks" to "ids"
     if "mints" in dtoken and isinstance(dtoken["mints"], dict):
         dtoken["mints"] = list(dtoken["mints"].values())
+        for m in dtoken["mints"]:
+            m["ids"] = m.pop("ks")
 
     assert "proofs" in dtoken, Exception("no proofs in token")
     includes_mint_info: bool = "mints" in dtoken and dtoken.get("mints") is not None

--- a/cashu/wallet/cli.py
+++ b/cashu/wallet/cli.py
@@ -392,6 +392,10 @@ async def receive(ctx, token: str, lock: str):
     if "tokens" in dtoken:
         dtoken["proofs"] = dtoken.pop("tokens")
 
+    # backwards compatibility wallet to wallet < 0.8.3: V2 tokens got rid of the "MINT_NAME" key in "mints"
+    if "mints" in dtoken and isinstance(dtoken["mints"], dict):
+        dtoken["mints"] = list(dtoken["mints"].values())
+
     assert "proofs" in dtoken, Exception("no proofs in token")
     includes_mint_info: bool = "mints" in dtoken and dtoken.get("mints") is not None
 

--- a/cashu/wallet/cli.py
+++ b/cashu/wallet/cli.py
@@ -406,9 +406,9 @@ async def receive(ctx, token: str, lock: str):
     # and ask the user if they want to trust the new mitns
     if includes_mint_info:
         # we ask the user to confirm any new mints the tokens may include
-        await verify_mints(ctx, dtoken)
+        await verify_mints(ctx, tokenObj)
         # redeem tokens with new wallet instances
-        await redeem_multimint(ctx, dtoken, script, signature)
+        await redeem_multimint(ctx, tokenObj, script, signature)
         # reload main wallet so the balance updates
         await wallet.load_proofs()
     else:

--- a/cashu/wallet/clihelpers.py
+++ b/cashu/wallet/clihelpers.py
@@ -3,17 +3,20 @@ import urllib.parse
 
 import click
 
-from cashu.core.base import Proof, TokenV2, TokenV2Mint, WalletKeyset
+from cashu.core.base import Proof, TokenV2Mint, TokenV2, WalletKeyset
 from cashu.core.settings import CASHU_DIR, MINT_URL
 from cashu.wallet.crud import get_keyset
 from cashu.wallet.wallet import Wallet as Wallet
 
 
 async def verify_mints(ctx, dtoken):
+    """
+    A helper function that takes a deserialized TokenV2 `dtoken`
+    """
     trust_token_mints = True
-    for mint_id in dtoken.get("mints"):
-        for keyset in set(dtoken["mints"][mint_id]["ids"]):
-            mint_url = dtoken["mints"][mint_id]["url"]
+    for mint in dtoken.get("mints"):
+        for keyset in set(mint["ids"]):
+            mint_url = mint["url"]
             # init a temporary wallet object
             keyset_wallet = Wallet(
                 mint_url, os.path.join(CASHU_DIR, ctx.obj["WALLET_NAME"])
@@ -50,9 +53,9 @@ async def verify_mints(ctx, dtoken):
 async def redeem_multimint(ctx, dtoken, script, signature):
     # we get the mint information in the token and load the keys of each mint
     # we then redeem the tokens for each keyset individually
-    for mint_id in dtoken.get("mints"):
-        for keyset in set(dtoken["mints"][mint_id]["ids"]):
-            mint_url = dtoken["mints"][mint_id]["url"]
+    for mint in dtoken.get("mints"):
+        for keyset in set(mint["ids"]):
+            mint_url = mint["url"]
             # init a temporary wallet object
             keyset_wallet = Wallet(
                 mint_url, os.path.join(CASHU_DIR, ctx.obj["WALLET_NAME"])

--- a/cashu/wallet/clihelpers.py
+++ b/cashu/wallet/clihelpers.py
@@ -8,6 +8,7 @@ from cashu.core.base import Proof, TokenV2, TokenV2Mint, WalletKeyset
 from cashu.core.settings import CASHU_DIR, MINT_URL
 from cashu.wallet.crud import get_keyset
 from cashu.wallet.wallet import Wallet as Wallet
+from loguru import logger
 
 
 async def verify_mints(ctx, token: TokenV2):
@@ -21,7 +22,7 @@ async def verify_mints(ctx, token: TokenV2):
 
     if token.mints is None:
         return
-
+    logger.debug(f"Verifying mints")
     trust_token_mints = True
     for mint in token.mints:
         for keyset in set(mint.ids):
@@ -54,6 +55,8 @@ async def verify_mints(ctx, token: TokenV2):
                     default=True,
                 )
                 trust_token_mints = True
+            else:
+                logger.debug(f"We know keyset {mint_keysets.id} already")
     assert trust_token_mints, Exception("Aborted!")
 
 
@@ -66,8 +69,10 @@ async def redeem_multimint(ctx, token: TokenV2, script, signature):
     # we then redeem the tokens for each keyset individually
     if token.mints is None:
         return
+
     for mint in token.mints:
         for keyset in set(mint.ids):
+            logger.debug(f"Redeeming tokens from keyset {keyset}")
             # init a temporary wallet object
             keyset_wallet = Wallet(
                 mint.url, os.path.join(CASHU_DIR, ctx.obj["WALLET_NAME"])

--- a/cashu/wallet/clihelpers.py
+++ b/cashu/wallet/clihelpers.py
@@ -1,11 +1,10 @@
 import os
 import urllib.parse
+from typing import List
 
 import click
 
-from typing import List
-
-from cashu.core.base import Proof, TokenV2Mint, TokenV2, WalletKeyset
+from cashu.core.base import Proof, TokenV2, TokenV2Mint, WalletKeyset
 from cashu.core.settings import CASHU_DIR, MINT_URL
 from cashu.wallet.crud import get_keyset
 from cashu.wallet.wallet import Wallet as Wallet

--- a/cashu/wallet/clihelpers.py
+++ b/cashu/wallet/clihelpers.py
@@ -3,7 +3,7 @@ import urllib.parse
 
 import click
 
-from cashu.core.base import Proof, TokenMintV2, TokenV2, WalletKeyset
+from cashu.core.base import Proof, TokenV2, TokenV2Mint, WalletKeyset
 from cashu.core.settings import CASHU_DIR, MINT_URL
 from cashu.wallet.crud import get_keyset
 from cashu.wallet.wallet import Wallet as Wallet
@@ -12,7 +12,7 @@ from cashu.wallet.wallet import Wallet as Wallet
 async def verify_mints(ctx, dtoken):
     trust_token_mints = True
     for mint_id in dtoken.get("mints"):
-        for keyset in set(dtoken["mints"][mint_id]["ks"]):
+        for keyset in set(dtoken["mints"][mint_id]["ids"]):
             mint_url = dtoken["mints"][mint_id]["url"]
             # init a temporary wallet object
             keyset_wallet = Wallet(
@@ -51,7 +51,7 @@ async def redeem_multimint(ctx, dtoken, script, signature):
     # we get the mint information in the token and load the keys of each mint
     # we then redeem the tokens for each keyset individually
     for mint_id in dtoken.get("mints"):
-        for keyset in set(dtoken["mints"][mint_id]["ks"]):
+        for keyset in set(dtoken["mints"][mint_id]["ids"]):
             mint_url = dtoken["mints"][mint_id]["url"]
             # init a temporary wallet object
             keyset_wallet = Wallet(
@@ -153,7 +153,7 @@ async def proofs_to_token(wallet, proofs, url: str):
     """
     # and add url and keyset id to token
     token: TokenV2 = await wallet._make_token(proofs, include_mints=False)
-    token.mints = {}
+    token.mints = []
 
     # get keysets of proofs
     keysets = list(set([p.id for p in proofs]))
@@ -168,6 +168,6 @@ async def proofs_to_token(wallet, proofs, url: str):
         input(f"Enter mint URL (press enter for default {MINT_URL}): ") or MINT_URL
     )
 
-    token.mints[url] = TokenMintV2(url=url, ks=keysets)  # type: ignore
+    token.mints.append(TokenV2Mint(url=url, ks=keysets))
     token_serialized = await wallet._serialize_token_base64(token)
     return token_serialized

--- a/cashu/wallet/clihelpers.py
+++ b/cashu/wallet/clihelpers.py
@@ -3,12 +3,12 @@ import urllib.parse
 from typing import List
 
 import click
+from loguru import logger
 
 from cashu.core.base import Proof, TokenV2, TokenV2Mint, WalletKeyset
 from cashu.core.settings import CASHU_DIR, MINT_URL
 from cashu.wallet.crud import get_keyset
 from cashu.wallet.wallet import Wallet as Wallet
-from loguru import logger
 
 
 async def verify_mints(ctx, token: TokenV2):

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -376,7 +376,7 @@ class LedgerAPI:
         """
         payload = PostMeltRequest(proofs=proofs, invoice=invoice)
 
-        def _meltequest_include_fields(proofs):
+        def _meltrequest_include_fields(proofs):
             """strips away fields from the model that aren't necessary for the /melt"""
             proofs_include = {"id", "amount", "secret", "C", "script"}
             return {
@@ -388,7 +388,7 @@ class LedgerAPI:
         self.s = self._set_requests()
         resp = self.s.post(
             self.url + "/melt",
-            json=payload.dict(include=_meltequest_include_fields(proofs)),  # type: ignore
+            json=payload.dict(include=_meltrequest_include_fields(proofs)),  # type: ignore
         )
         resp.raise_for_status()
         return_dict = resp.json()

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -404,6 +404,7 @@ class Wallet(LedgerAPI):
         self.db = Database("wallet", db)
         self.proofs: List[Proof] = []
         self.name = name
+        logger.debug(f"Wallet initalized with mint URL {url}")
 
     # ---------- API ----------
 

--- a/docs/specs/00.md
+++ b/docs/specs/00.md
@@ -113,7 +113,7 @@ W3siaWQiOiAiRFNBbDludnZ5ZnZhIiwgImFtb3VudCI6IDgsICJzZWNyZXQiOiAiRGJSS0l5YTBldGR3
 
 #### 0.2.2 - V2 tokens
 
-This token format includes information about the mint as well. The field `proofs` is like a V1 token. Additionally, the field `mints` can include a list of multiple mints from which the `proofs` are from. The `url` field is the URL of the mint. `ks` is a list of the keyset IDs belonging to this mint. All keyset IDs of the `proofs` must be present here to allow a wallet to map each proof to a mint.
+This token format includes information about the mint as well. The field `proofs` is like a V1 token. Additionally, the field `mints` can include an array (list) of multiple mints from which the `proofs` are from. The `url` field is the URL of the mint. `ids` is a list of the keyset IDs belonging to this mint. It is important that all keyset IDs of the `proofs` must be present here to allow a wallet to map each proof to a mint.
 
 ##### Example JSON:
 
@@ -123,29 +123,30 @@ This token format includes information about the mint as well. The field `proofs
     {
       "id": "DSAl9nvvyfva",
       "amount": 2,
-      "secret": "bdYCbHGONundLeYvv1P5dQ",
-      "C": "02e6117fb1b1633a8c1657ed34ab25ecf8d4974091179c4773ec59f85f4e3991cf"
+      "secret": "EhpennC9qB3iFlW8FZ_pZw",
+      "C": "02c020067db727d586bc3183aecf97fcb800c3f4cc4759f69c626c9db5d8f5b5d4"
     },
     {
       "id": "DSAl9nvvyfva",
       "amount": 8,
-      "secret": "KxyUPt5Mur_-RV8pCECJ6A",
-      "C": "03b9dcdb7f195e07218b95b7c2dadc8289159fc44047439830f765b8c50bfb6bda"
+      "secret": "TmS6Cv0YT5PU_5ATVKnukw",
+      "C": "02ac910bef28cbe5d7325415d5c263026f15f9b967a079ca9779ab6e5c2db133a7"
     }
   ],
-  "mints": {
-    "MINT_NAME": {
-      "url": "http://server.host:3339",
-      "ks": ["DSAl9nvvyfva"]
+  "mints": [
+    {
+      "url": "https://8333.space:3338",
+      "ids": ["DSAl9nvvyfva"]
     }
-  }
+  ]
 }
+
 ```
 
 When serialized, this becomes:
 
 ```
-eyJwcm9vZnMiOlt7ImlkIjoiRFNBbDludnZ5ZnZhIiwiYW1vdW50IjoyLCJzZWNyZXQiOiJiZFlDYkhHT051bmRMZVl2djFQNWRRIiwiQyI6IjAyZTYxMTdmYjFiMTYzM2E4YzE2NTdlZDM0YWIyNWVjZjhkNDk3NDA5MTE3OWM0NzczZWM1OWY4NWY0ZTM5OTFjZiJ9LHsiaWQiOiJEU0FsOW52dnlmdmEiLCJhbW91bnQiOjgsInNlY3JldCI6Ikt4eVVQdDVNdXJfLVJWOHBDRUNKNkEiLCJDIjoiMDNiOWRjZGI3ZjE5NWUwNzIxOGI5NWI3YzJkYWRjODI4OTE1OWZjNDQwNDc0Mzk4MzBmNzY1YjhjNTBiZmI2YmRhIn1dLCJtaW50cyI6eyJNSU5UX05BTUUiOnsidXJsIjoiaHR0cDovL3NlcnZlci5ob3N0OjMzMzkiLCJrcyI6WyJEU0FsOW52dnlmdmEiXX19fQ==
+eyJwcm9vZnMiOlt7ImlkIjoiRFNBbDludnZ5ZnZhIiwiYW1vdW50IjoyLCJzZWNyZXQiOiJFaHBlbm5DOXFCM2lGbFc4RlpfcFp3IiwiQyI6IjAyYzAyMDA2N2RiNzI3ZDU4NmJjMzE4M2FlY2Y5N2ZjYjgwMGMzZjRjYzQ3NTlmNjljNjI2YzlkYjVkOGY1YjVkNCJ9LHsiaWQiOiJEU0FsOW52dnlmdmEiLCJhbW91bnQiOjgsInNlY3JldCI6IlRtUzZDdjBZVDVQVV81QVRWS251a3ciLCJDIjoiMDJhYzkxMGJlZjI4Y2JlNWQ3MzI1NDE1ZDVjMjYzMDI2ZjE1ZjliOTY3YTA3OWNhOTc3OWFiNmU1YzJkYjEzM2E3In1dLCJtaW50cyI6W3sidXJsIjoiaHR0cHM6Ly84MzMzLnNwYWNlOjMzMzgiLCJpZHMiOlsiRFNBbDludnZ5ZnZhIl19XX0=
 ```
 
 [00]: 00.md

--- a/docs/specs/05.md
+++ b/docs/specs/05.md
@@ -2,7 +2,7 @@
 
 Melting tokens is the opposite of minting them (see #4): the wallet `Alice` sends `Proofs` to the mint `Bob` together with a bolt11 Lightning invoice that `Alice` wants to be paid. To melt tokens, `Alice` sends a `POST /melt` request with a JSON body to the mint. The `Proofs` included in the request will be burned by the mint and the mint will pay the invoice in exchange.
 
-`Alice`'s request **MUST** include a `MeltRequest` ([TODO: Link MeltRequest]) JSON body with `Proofs` that have at least the amount of the invoice to be paid.
+`Alice`'s request **MUST** include a `PostMeltRequest` ([TODO: Link PostMeltRequest]) JSON body with `Proofs` that have at least the amount of the invoice to be paid.
 
 ## Example
 
@@ -12,7 +12,7 @@ Melting tokens is the opposite of minting them (see #4): the wallet `Alice` send
 POST https://mint.host:3338/melt
 ```
 
-With the data being of the form `MeltRequest`:
+With the data being of the form `PostMeltRequest`:
 
 ```json
 {

--- a/docs/specs/06.md
+++ b/docs/specs/06.md
@@ -22,7 +22,7 @@ Another case of how split can be useful becomes apparent if we follow up the exa
 POST https://mint.host:3338/split
 ```
 
-With the data being of the form `SplitRequest`:
+With the data being of the form `PostSplitRequest`:
 
 ```json
 {

--- a/docs/specs/cashu_client_spec.md
+++ b/docs/specs/cashu_client_spec.md
@@ -92,12 +92,12 @@ Here we describe how `Carol` can redeem new tokens from `Bob` that she previousl
 Note that the following steps can also be performed by `Alice` herself if she wants to cancel the pending token transfer and claim them for herself.
 
 - `Carol` constructs a list of `<blinded_message>`'s each with the same amount as the list list of tokens that she received. This can be done by the same procedure as during the minting of new tokens in Section 2 [*TODO: update ref*] or during sending in Section 3 [*TODO: update ref*] since the splitting into amounts is deterministic.
-- `Carol` performs the same steps as `Alice` when she split the tokens before sending it to her and calls the endpoint `POIT /split` with the JSON `SplitRequests` as the body of the request.
+- `Carol` performs the same steps as `Alice` when she split the tokens before sending it to her and calls the endpoint `POIT /split` with the JSON `PostSplitRequests` as the body of the request.
 
 ## 5 - Burn sent tokens
 Here we describe how `Alice` checks with the mint whether the tokens she sent `Carol` have been redeemed so she can safely delete them from her database. This step is optional but highly recommended so `Alice` can properly account for the tokens and adjust her balance accordingly.
 - `Alice` loads all `<send_proofs>` with `pending=True` from her database and might group them by the `send_id`.
-- `Alice` constructs a JSON of the form `{"proofs" : [{"amount" : <amount>, "secret" : s, "C" : Z}, ...]}` from these (grouped) tokens. [*TODO: this object is called CheckRequest*]
+- `Alice` constructs a JSON of the form `{"proofs" : [{"amount" : <amount>, "secret" : s, "C" : Z}, ...]}` from these (grouped) tokens. [*TODO: this object is called GetCheckSpendableRequest*]
 - `Alice` sends them to the mint `Bob` via the endpoint `POST /check` with the JSON as the body of the request.
 - `Alice` receives a JSON of the form `{"1" : <spendable : bool>, "2" : ...}` where `"1"` is the index of the proof she sent to the mint before and `<spendable>` is a boolean that is `True` if the token has not been claimed yet by `Carol` and `False` if it has already been claimed.
 - If `<spendable>` is `False`, `Alice` removes the proof [*NOTE: consistent name?*] from her list of spendable proofs.
@@ -109,7 +109,7 @@ Here we describe how `Alice` can request from `Bob` to make a Lightning payment 
 - `Alice` asks `Bob` for the Lightning fee via `GET /checkfee` with the body `CheckFeeRequest` being the json `{pr : <invoice>}`
 - `Alice` receives the `CheckFeeResponse` in the form of the json `{"fee" : <fee>}` resulting in `<total> = <invoice_amount> + <fee>`.
 - `Alice` now performs the same set of instructions as in Step 3.1 and 3.2 and splits her spendable tokens into a set `<keep_proofs>` that she keeps and and a set `<send_proofs>` with a sum of at least `<total>` that she can send for making the Lightning payment.
-- `Alice` constructs the JSON `MeltRequest` of the form `{"proofs" : <List[Proof]>, "invoice" : <invoice>}` [*NOTE: Maybe use notation List[Proof] everywhere. Used MeltRequest here, maybe define each payload at the beginning of each section.*]
+- `Alice` constructs the JSON `PostMeltRequest` of the form `{"proofs" : <List[Proof]>, "invoice" : <invoice>}` [*NOTE: Maybe use notation List[Proof] everywhere. Used PostMeltRequest here, maybe define each payload at the beginning of each section.*]
 - `Alice` requests a payment from `Bob` via the endpoint `POST /melt` with the JSON as the body of the request.
 - `Alice` receives a JSON of the form `{"paid" :  <status:bool>}` with `<status>` being `True` if the payment was successful and `False` otherwise.
 - If `<status> == True`, `Alice` removes `<send_proofs>` from her database of spendable tokens [*NOTE: called it tokens again*]
@@ -121,5 +121,5 @@ Here we describe how `Alice` can request from `Bob` to make a Lightning payment 
 
 # Todo:
 - Call subsections 1. and 1.2 etc so they can be referenced
-- Define objets like `BlindedMessages` and `SplitRequests` once when they appear and reuse them.
+- Define objets like `BlindedMessages` and `PostSplitRequests` once when they appear and reuse them.
 - Clarify whether a `TOKEN` is a single Proof or a list of Proofs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cashu"
-version = "0.8.2"
+version = "0.8.3"
 description = "Ecash wallet and mint."
 authors = ["calle <callebtc@protonmail.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ entry_points = {"console_scripts": ["cashu = cashu.wallet.cli:cli"]}
 
 setuptools.setup(
     name="cashu",
-    version="0.8.2",
+    version="0.8.3",
     description="Ecash wallet and mint for Bitcoin Lightning",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
`TokenV2` update: `mints` object is now a list (array) and not a dictionary where the keys have been variable. 

The field `ks` is now called `ids` to better reflect the `id` field in the `proofs` field. 

New format: 

```json
{
  "proofs": [
    {
      "id": "DSAl9nvvyfva",
      "amount": 2,
      "secret": "EhpennC9qB3iFlW8FZ_pZw",
      "C": "02c020067db727d586bc3183aecf97fcb800c3f4cc4759f69c626c9db5d8f5b5d4"
    },
    {
      "id": "DSAl9nvvyfva",
      "amount": 8,
      "secret": "TmS6Cv0YT5PU_5ATVKnukw",
      "C": "02ac910bef28cbe5d7325415d5c263026f15f9b967a079ca9779ab6e5c2db133a7"
    }
  ],
  "mints": [
    {
      "url": "https://8333.space:3338",
      "ids": ["DSAl9nvvyfva"]
    }
  ]
}
```