### PR TITLE
Fix/multimind_redeem_unused_keysets

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ cashu info
 
 Returns:
 ```bash
-Version: 0.9.0
+Version: 0.9.1
 Debug: False
 Cashu dir: /home/user/.cashu
 Wallet: wallet

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -66,4 +66,4 @@ NOSTR_RELAYS = env.list(
 )
 
 MAX_ORDER = 64
-VERSION = "0.9.0"
+VERSION = "0.9.1"

--- a/cashu/wallet/cli_helpers.py
+++ b/cashu/wallet/cli_helpers.py
@@ -29,10 +29,12 @@ async def verify_mints(ctx: Context, token: TokenV2):
 
     if token.mints is None:
         return
+    proofs_keysets = set([p.id for p in token.proofs])
+
     logger.debug(f"Verifying mints")
     trust_token_mints = True
     for mint in token.mints:
-        for keyset in set(mint.ids):
+        for keyset in set([id for id in mint.ids if id in proofs_keysets]):
             # init a temporary wallet object
             keyset_wallet = Wallet(
                 mint.url, os.path.join(CASHU_DIR, ctx.obj["WALLET_NAME"])

--- a/cashu/wallet/cli_helpers.py
+++ b/cashu/wallet/cli_helpers.py
@@ -77,8 +77,10 @@ async def redeem_multimint(ctx: Context, token: TokenV2, script, signature):
     if token.mints is None:
         return
 
+    proofs_keysets = set([p.id for p in token.proofs])
+
     for mint in token.mints:
-        for keyset in set(mint.ids):
+        for keyset in set([id for id in mint.ids if id in proofs_keysets]):
             logger.debug(f"Redeeming tokens from keyset {keyset}")
             # init a temporary wallet object
             keyset_wallet = Wallet(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cashu"
-version = "0.9.0"
+version = "0.9.1"
 description = "Ecash wallet and mint."
 authors = ["calle <callebtc@protonmail.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ entry_points = {"console_scripts": ["cashu = cashu.wallet.cli:cli"]}
 
 setuptools.setup(
     name="cashu",
-    version="0.9.0",
+    version="0.9.1",
     description="Ecash wallet and mint for Bitcoin Lightning",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixes a problem where entries in the `token.mints.ids` field would be verified even if no token was present for that keyset.