### PR TITLE
nostr: send to nip05

### DIFF
--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -270,10 +270,12 @@ async def send(ctx: Context, amount: int, lock: str, legacy: bool):
 
 @cli.command("send", help="Send tokens.")
 @click.argument("amount", type=int)
+@click.argument("nostr", type=str, required=False)
 @click.option(
     "--nostr",
     "-n",
-    help="Send to nostr pubkey",
+    "nopt",
+    help="Send to nostr pubkey.",
     type=str,
 )
 @click.option("--lock", "-l", default=None, help="Lock tokens (P2SH).", type=str)
@@ -302,15 +304,16 @@ async def send_command(
     ctx,
     amount: int,
     nostr: str,
+    nopt: str,
     lock: str,
     legacy: bool,
     verbose: bool,
     yes: bool,
 ):
-    if nostr is None:
+    if not nostr and not nopt:
         await send(ctx, amount, lock, legacy)
     else:
-        await send_nostr(ctx, amount, nostr, verbose, yes)
+        await send_nostr(ctx, amount, nostr or nopt, verbose, yes)
 
 
 async def receive(ctx: Context, token: str, lock: str):

--- a/cashu/wallet/cli/nostr.py
+++ b/cashu/wallet/cli/nostr.py
@@ -82,6 +82,7 @@ async def send_nostr(ctx: Context, amount: int, pubkey: str, verbose: bool, yes:
 
     client.dm(token, pubkey_to)
     print(f"Token sent to {pubkey_to.bech32()}")
+    await asyncio.sleep(5)
     client.close()
 
 

--- a/cashu/wallet/cli/nostr.py
+++ b/cashu/wallet/cli/nostr.py
@@ -24,6 +24,9 @@ async def nip5_to_pubkey(wallet: Wallet, address: str):
     """
     # we will be using the requests session from the wallet
     await wallet._init_s()
+    # if no username is given, use default _ (NIP-05 stuff)
+    if "@" not in address:
+        address = "_@" + address
     # now we can use it
     user, host = address.split("@")
     resp_dict = {}
@@ -50,7 +53,8 @@ async def send_nostr(ctx: Context, amount: int, pubkey: str, verbose: bool, yes:
     # load a wallet for the chosen mint
     wallet = await get_mint_wallet(ctx)
 
-    if "@" in pubkey:
+    if "@" in pubkey or "." in pubkey:
+        # parses user@domain.com and domain.com (which is _@domain.com)
         pubkey = await nip5_to_pubkey(wallet, pubkey)
 
     await wallet.load_proofs()


### PR DESCRIPTION
- easier command for sending `cashu send 10 user@domain.com` without `-n` flag (optional now)
- sleep 5s after sending to make sure websockets have sent out data
- parsing for nip05 identifiers without a user, i.e. `me.com` becomes `_@me.com`