### PR TITLE
Fix: TypeError in burn token

### DIFF
--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -456,7 +456,9 @@ async def burn(ctx: Context, token: str, all: bool, force: bool, delete: str):
         proofs = [proof for proof in reserved_proofs if proof["send_id"] == delete]
     else:
         # check only the specified ones
-        proofs = [Proof(**p) for p in json.loads(base64.urlsafe_b64decode(token))["proofs"]]
+        proofs = [
+            Proof(**p) for p in json.loads(base64.urlsafe_b64decode(token))["proofs"]
+        ]
 
     if delete:
         await wallet.invalidate(proofs, check_spendable=False)

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -456,7 +456,7 @@ async def burn(ctx: Context, token: str, all: bool, force: bool, delete: str):
         proofs = [proof for proof in reserved_proofs if proof["send_id"] == delete]
     else:
         # check only the specified ones
-        proofs = [Proof(**p) for p in json.loads(base64.urlsafe_b64decode(token))]
+        proofs = [Proof(**p) for p in json.loads(base64.urlsafe_b64decode(token))["proofs"]]
 
     if delete:
         await wallet.invalidate(proofs, check_spendable=False)


### PR DESCRIPTION
When burning specific token via cashu burn "token", there was a TypeError in line 459 of cli.py:
`proofs = [Proof(**p) for p in json.loads(base64.urlsafe_b64decode(token))]`

`
TypeError: cashu.core.base.Proof() argument after ** must be a mapping, not str
`