### PR TITLE
Fix/ln unsuccessful payment

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ cashu info
 
 Returns:
 ```bash
-Version: 0.11.1
+Version: 0.11.2
 Debug: False
 Cashu dir: /home/user/.cashu
 Wallet: wallet

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -8,7 +8,7 @@ from pydantic import BaseSettings, Extra, Field, validator
 
 env = Env()
 
-VERSION = "0.11.1"
+VERSION = "0.11.2"
 
 
 def find_env_file():

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -614,6 +614,8 @@ class Ledger:
                         ln_fee_msat=fee_msat,
                         outputs=outputs,
                     )
+            else:
+                raise Exception("Lightning payment unsuccessful.")
 
         except Exception as e:
             raise e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cashu"
-version = "0.11.1"
+version = "0.11.2"
 description = "Ecash wallet and mint."
 authors = ["calle <callebtc@protonmail.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ entry_points = {"console_scripts": ["cashu = cashu.wallet.cli.cli:cli"]}
 
 setuptools.setup(
     name="cashu",
-    version="0.11.1",
+    version="0.11.2",
     description="Ecash wallet and mint for Bitcoin Lightning",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Wallets that did not explicitly check for the status of the payment now also receive an HTTP error if a LN payment was unsuccessful.