### PR TITLE
Allow setting mint as peg-out only

### DIFF
--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -53,6 +53,7 @@ class MintSettings(CashuSettings):
     mint_listen_port: int = Field(default=3338)
     mint_lightning_backend: str = Field(default="LNbitsWallet")
     mint_database: str = Field(default="data/mint")
+    mint_peg_out_only: bool = Field(default=False)
 
     mint_lnbits_endpoint: str = Field(default=None)
     mint_lnbits_key: str = Field(default=None)

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -121,13 +121,12 @@ async def mint(
     """
     if settings.mint_peg_out_only:
         return CashuError(code=0, error="Mint does not allow minting new tokens.")
-    else:
-        try:
-            promises = await ledger.mint(payload.outputs, payment_hash=payment_hash)
-            blinded_signatures = PostMintResponse(promises=promises)
-            return blinded_signatures
-        except Exception as exc:
-            return CashuError(code=0, error=str(exc))
+    try:
+        promises = await ledger.mint(payload.outputs, payment_hash=payment_hash)
+        blinded_signatures = PostMintResponse(promises=promises)
+        return blinded_signatures
+    except Exception as exc:
+        return CashuError(code=0, error=str(exc))
 
 
 @router.post(

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -90,17 +90,20 @@ async def keysets() -> KeysetsResponse:
 
 
 @router.get("/mint", name="Request mint", summary="Request minting of new tokens")
-async def request_mint(amount: int = 0) -> GetMintResponse:
+async def request_mint(amount: int = 0) -> Union[GetMintResponse, CashuError]:
     """
     Request minting of new tokens. The mint responds with a Lightning invoice.
     This endpoint can be used for a Lightning invoice UX flow.
 
     Call `POST /mint` after paying the invoice.
     """
-    payment_request, payment_hash = await ledger.request_mint(amount)
-    print(f"Lightning invoice: {payment_request}")
-    resp = GetMintResponse(pr=payment_request, hash=payment_hash)
-    return resp
+    if settings.mint_peg_out_only:
+        return CashuError(code=0, error="Mint does not allow minting new tokens.")
+    else:
+        payment_request, payment_hash = await ledger.request_mint(amount)
+        print(f"Lightning invoice: {payment_request}")
+        resp = GetMintResponse(pr=payment_request, hash=payment_hash)
+        return resp
 
 
 @router.post(
@@ -117,12 +120,15 @@ async def mint(
 
     Call this endpoint after `GET /mint`.
     """
-    try:
-        promises = await ledger.mint(payload.outputs, payment_hash=payment_hash)
-        blinded_signatures = PostMintResponse(promises=promises)
-        return blinded_signatures
-    except Exception as exc:
-        return CashuError(code=0, error=str(exc))
+    if settings.mint_peg_out_only:
+        return CashuError(code=0, error="Mint does not allow minting new tokens.")
+    else:
+        try:
+            promises = await ledger.mint(payload.outputs, payment_hash=payment_hash)
+            blinded_signatures = PostMintResponse(promises=promises)
+            return blinded_signatures
+        except Exception as exc:
+            return CashuError(code=0, error=str(exc))
 
 
 @router.post(

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -99,11 +99,10 @@ async def request_mint(amount: int = 0) -> Union[GetMintResponse, CashuError]:
     """
     if settings.mint_peg_out_only:
         return CashuError(code=0, error="Mint does not allow minting new tokens.")
-    else:
-        payment_request, payment_hash = await ledger.request_mint(amount)
-        print(f"Lightning invoice: {payment_request}")
-        resp = GetMintResponse(pr=payment_request, hash=payment_hash)
-        return resp
+    payment_request, payment_hash = await ledger.request_mint(amount)
+    print(f"Lightning invoice: {payment_request}")
+    resp = GetMintResponse(pr=payment_request, hash=payment_hash)
+    return resp
 
 
 @router.post(


### PR DESCRIPTION
See #151.
Adds flag `mint_peg_out_only` in settings. If set and someone tries to mint or requests minting, an error is raised. 