### PR TITLE
fix: load mint with most recent keyset

### DIFF
--- a/cashu/wallet/cli/cli_helpers.py
+++ b/cashu/wallet/cli/cli_helpers.py
@@ -185,11 +185,11 @@ async def get_mint_wallet(ctx: Context):
     Helper function that asks the user for an input to select which mint they want to load.
     Useful for selecting the mint that the user wants to send tokens from.
     """
+    # we load a dummy wallet so we can check the balance per mint
     wallet: Wallet = ctx.obj["WALLET"]
-    await wallet.load_mint()
-
     mint_balances = await wallet.balance_per_minturl()
 
+    # if we have balances on more than one mint, we ask the user to select one
     if len(mint_balances) > 1:
         await print_mint_balances(ctx, wallet, show_mints=True)
 
@@ -215,11 +215,7 @@ async def get_mint_wallet(ctx: Context):
     mint_wallet = Wallet(
         mint_url, os.path.join(settings.cashu_dir, ctx.obj["WALLET_NAME"])
     )
-    mint_keysets: WalletKeyset = await get_keyset(mint_url=mint_url, db=mint_wallet.db)  # type: ignore
-
-    # load the keys
-    assert mint_keysets.id
-    await mint_wallet.load_mint(keyset_id=mint_keysets.id)
+    await mint_wallet.load_mint()
 
     return mint_wallet
 


### PR DESCRIPTION
Wallet used to load the mint with the keyset_id it encountered first in the database instead of loading the most recent one which is determined by asking the mint directly because we use `mint_wallet.load_mint(keyset_id=None)` now.