### PR TITLE
load keys of output, not of inputs

### DIFF
--- a/cashu/wallet/cli/cli_helpers.py
+++ b/cashu/wallet/cli/cli_helpers.py
@@ -119,8 +119,7 @@ async def redeem_TokenV2_multimint(ctx: Context, token: TokenV2, script, signatu
                 mint.url, os.path.join(settings.cashu_dir, ctx.obj["WALLET_NAME"])
             )
 
-            # load the keys
-            await keyset_wallet.load_mint(keyset_id=keyset)
+            await keyset_wallet.load_mint()
 
             # redeem proofs of this keyset
             redeem_proofs = [p for p in token.proofs if p.id == keyset]
@@ -142,10 +141,10 @@ async def redeem_TokenV3_multimint(ctx: Context, token: TokenV3, script, signatu
         )
         await verify_mint(mint_wallet, t.mint)
         keysets = mint_wallet._get_proofs_keysets(t.proofs)
-        # logger.debug(f"Keysets in tokens: {keysets}")
+        logger.debug(f"Keysets in tokens: {keysets}")
         # loop over all keysets
         for keyset in set(keysets):
-            await mint_wallet.load_mint(keyset_id=keyset)
+            await mint_wallet.load_mint()
             # redeem proofs of this keyset
             redeem_proofs = [p for p in t.proofs if p.id == keyset]
             _, _ = await mint_wallet.redeem(

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -116,10 +116,16 @@ class LedgerAPI:
         """Returns proofs of promise from promises. Wants secrets and blinding factors rs."""
         proofs: List[Proof] = []
         for promise, secret, r in zip(promises, secrets, rs):
+            logger.trace(f"Creating proof with keyset {self.keyset_id} =+ {promise.id}")
+            assert (
+                self.keyset_id == promise.id
+            ), "our keyset id does not match promise id."
+
             C_ = PublicKey(bytes.fromhex(promise.C_), raw=True)
             C = b_dhke.step3_alice(C_, r, self.public_keys[promise.amount])
+
             proof = Proof(
-                id=self.keyset_id,
+                id=promise.id,
                 amount=promise.amount,
                 C=C.serialize().hex(),
                 secret=secret,


### PR DESCRIPTION
Wallet loaded keys of the redeemed token (input) instead of the newly issued tokens (outputs). Mint public keys are used in `step3_Alice()`