### PR TITLE
fix double "or" typo in burn parameter validation error message

### DIFF
--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -441,7 +441,7 @@ async def burn(ctx: Context, token: str, all: bool, force: bool, delete: str):
         await wallet.load_mint()
     if not (all or token or force or delete) or (token and all):
         print(
-            "Error: enter a token or use --all to burn all pending tokens, --force to check all tokens or"
+            "Error: enter a token or use --all to burn all pending tokens, --force to check all tokens "
             "or --delete with send ID to force-delete pending token from list if mint is unavailable."
         )
         return


### PR DESCRIPTION
While making myself familiar with some of the available cashu commands, I noticed that `burn` command parameter validation error message contains "oror" instead of "or". (Found my way here through WBD episode #647, the project looks very promising!).