### PR TITLE
fix: test_step2

### DIFF
--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -70,7 +70,7 @@ def test_step2():
         ),
         raw=True,
     )
-    C_ = B_.mult(a)
+    C_ = step2_bob(B_, a)
     assert (
         C_.serialize().hex()
         == "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2"


### PR DESCRIPTION
The test_step2() doesn't call step2_bob() of the b_dkhe module and therefore is only testing step1_alice()