### PR TITLE
Fix bug where no additional mints can be funded

### DIFF
--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -67,7 +67,7 @@ def cli(ctx: Context, host: str, walletname: str):
         ctx.obj["HOST"], os.path.join(settings.cashu_dir, walletname), name=walletname
     )
     ctx.obj["WALLET"] = wallet
-    asyncio.run(init_wallet(wallet))
+    asyncio.run(init_wallet(ctx.obj["WALLET"]))
 
     # MUTLIMINT: Select a wallet
     # only if a command is one of a subset that needs to specify a mint host
@@ -75,7 +75,6 @@ def cli(ctx: Context, host: str, walletname: str):
     if ctx.invoked_subcommand not in ["send", "invoice", "pay"] or host:
         return
     # else: we ask the user to select one
-    ctx.obj["WALLET"] = wallet  # set a wallet for get_mint_wallet in the next step
     ctx.obj["WALLET"] = asyncio.run(
         get_mint_wallet(ctx)
     )  # select a specific wallet by CLI input

--- a/cashu/wallet/cli/cli_helpers.py
+++ b/cashu/wallet/cli/cli_helpers.py
@@ -30,6 +30,13 @@ async def get_mint_wallet(ctx: Context):
     wallet: Wallet = ctx.obj["WALLET"]
     mint_balances = await wallet.balance_per_minturl()
 
+    # NOTE: This is a bit of a hack that is necessary because of the way the environment
+    # variables are handled right now. If there is a mint set through an env var and it
+    # is does not yet contain any proofs, we have to explicitly add it here, so it shows
+    # up in the mint selector.
+    if wallet.url not in mint_balances:
+        mint_balances[wallet.url] = {"balance": 0, "available": 0}
+
     # if we have balances on more than one mint, we ask the user to select one
     if len(mint_balances) > 1:
         await print_mint_balances(wallet, show_mints=True)

--- a/cashu/wallet/nostr.py
+++ b/cashu/wallet/nostr.py
@@ -9,7 +9,6 @@ from ..core.settings import settings
 from ..nostr.nostr.client.client import NostrClient
 from ..nostr.nostr.event import Event
 from ..nostr.nostr.key import PublicKey
-from .cli.cli_helpers import get_mint_wallet
 from .crud import get_nostr_last_check_timestamp, set_nostr_last_check_timestamp
 from .helpers import receive
 from .wallet import Wallet

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -938,6 +938,11 @@ class Wallet(LedgerAPI):
 
     async def balance_per_minturl(self):
         balances = await self._get_proofs_per_minturl(self.proofs)
+
+        # If the current Mint URL is not yet part of the database, we have to explicitly add it here.
+        if self.url not in balances:
+            balances[self.url] = []
+
         balances_return = {
             key: {
                 "balance": sum_proofs(proofs),

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -939,10 +939,6 @@ class Wallet(LedgerAPI):
     async def balance_per_minturl(self):
         balances = await self._get_proofs_per_minturl(self.proofs)
 
-        # If the current Mint URL is not yet part of the database, we have to explicitly add it here.
-        if self.url not in balances:
-            balances[self.url] = []
-
         balances_return = {
             key: {
                 "balance": sum_proofs(proofs),


### PR DESCRIPTION
As soon as one mint is in the database, the new multimint selector only considers this mint, even if the `MINT_` environment variables point to a different one. This commit fixes it by explicitly adding the set mint URL to the selector.

Additionally did some small cleanups.

Closes #204 