### PR TITLE
Assert `mint_private_key` is available at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Tor PID
+tor.pid
+
+# Default data directory
+/data

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -1,10 +1,10 @@
 import os
 import sys
 from pathlib import Path
-from typing import List, Union
+from typing import List
 
 from environs import Env  # type: ignore
-from pydantic import BaseSettings, Extra, Field, validator
+from pydantic import BaseSettings, Extra, Field
 
 env = Env()
 
@@ -13,14 +13,14 @@ VERSION = "0.12.0"
 
 def find_env_file():
     # env file: default to current dir, else home dir
-    ENV_FILE = os.path.join(os.getcwd(), ".env")
-    if not os.path.isfile(ENV_FILE):
-        ENV_FILE = os.path.join(str(Path.home()), ".cashu", ".env")
-    if os.path.isfile(ENV_FILE):
-        env.read_env(ENV_FILE)
+    env_file = os.path.join(os.getcwd(), ".env")
+    if not os.path.isfile(env_file):
+        env_file = os.path.join(str(Path.home()), ".cashu", ".env")
+    if os.path.isfile(env_file):
+        env.read_env(env_file)
     else:
-        ENV_FILE = ""
-    return ENV_FILE
+        env_file = ""
+    return env_file
 
 
 class CashuSettings(BaseSettings):
@@ -30,7 +30,7 @@ class CashuSettings(BaseSettings):
     lightning_reserve_fee_min: int = Field(default=2000)
     max_order: int = Field(default=64)
 
-    class Config:
+    class Config(BaseSettings.Config):
         env_file = find_env_file()
         env_file_encoding = "utf-8"
         case_sensitive = False

--- a/cashu/mint/startup.py
+++ b/cashu/mint/startup.py
@@ -21,6 +21,10 @@ for key, value in settings.dict().items():
 wallets_module = importlib.import_module("cashu.lightning")
 lightning_backend = getattr(wallets_module, settings.mint_lightning_backend)()
 
+assert (
+    settings.mint_private_key is not None
+), "Cannot create ledger: No private key set for mint. Check your environment settings."
+
 ledger = Ledger(
     db=Database("mint", settings.mint_database),
     seed=settings.mint_private_key,

--- a/cashu/mint/startup.py
+++ b/cashu/mint/startup.py
@@ -21,9 +21,7 @@ for key, value in settings.dict().items():
 wallets_module = importlib.import_module("cashu.lightning")
 lightning_backend = getattr(wallets_module, settings.mint_lightning_backend)()
 
-assert (
-    settings.mint_private_key is not None
-), "Cannot create ledger: No private key set for mint. Check your environment settings."
+assert settings.mint_private_key is not None, "No mint private key set."
 
 ledger = Ledger(
     db=Database("mint", settings.mint_database),


### PR DESCRIPTION
If the mint's private key is not available, the ledger cannot be created because no pubkey can be derived. We now explicitly assert this with a descriptive error message.

Additionally fixed some typing errors.

Closes #179