### PR TITLE
Allow to set maximum peg in/out for mint

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -116,6 +116,7 @@ class GetInfoResponse(BaseModel):
     contact: Optional[List[List[str]]] = None
     nuts: Optional[List[str]] = None
     motd: Optional[str] = None
+    parameter: Optional[dict] = None
 
 
 # ------- API: KEYS -------

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -55,6 +55,8 @@ class MintSettings(CashuSettings):
     mint_lightning_backend: str = Field(default="LNbitsWallet")
     mint_database: str = Field(default="data/mint")
     mint_peg_out_only: bool = Field(default=False)
+    mint_max_peg_in: int = Field(default=None)
+    mint_max_peg_out: int = Field(default=None)
 
     mint_lnbits_endpoint: str = Field(default=None)
     mint_lnbits_key: str = Field(default=None)

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -536,6 +536,10 @@ class Ledger:
         Returns:
             Tuple[str, str]: Bolt11 invoice and a hash (for looking it up later)
         """
+
+        if settings.mint_max_peg_in and amount > settings.mint_max_peg_in:
+            raise Exception(f"Maximum mint amount is {settings.mint_max_peg_in} sats.")
+
         payment_request, payment_hash = await self._request_lightning_invoice(amount)
         assert payment_request and payment_hash, Exception(
             "could not fetch invoice from Lightning backend"
@@ -621,8 +625,7 @@ class Ledger:
             invoice_amount = math.ceil(invoice_obj.amount_msat / 1000)
             if settings.mint_max_peg_out and invoice_amount > settings.mint_max_peg_out:
                 raise Exception(
-                    f"Maximum amount to pay is {settings.mint_max_peg_out} sats "
-                    f"({invoice_amount} sats requested)."
+                    f"Maximum melt amount is {settings.mint_max_peg_out} sats."
                 )
             fees_msat = await self.check_fees(invoice)
             assert total_provided >= invoice_amount + fees_msat / 1000, Exception(

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -539,6 +539,8 @@ class Ledger:
 
         if settings.mint_max_peg_in and amount > settings.mint_max_peg_in:
             raise Exception(f"Maximum mint amount is {settings.mint_max_peg_in} sats.")
+        if settings.mint_peg_out_only:
+            raise Exception("Mint does not allow minting new tokens.")
 
         payment_request, payment_hash = await self._request_lightning_invoice(amount)
         assert payment_request and payment_hash, Exception(

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -619,6 +619,9 @@ class Ledger:
             total_provided = sum_proofs(proofs)
             invoice_obj = bolt11.decode(invoice)
             invoice_amount = math.ceil(invoice_obj.amount_msat / 1000)
+            if settings.mint_max_peg_out and invoice_amount > settings.mint_max_peg_out:
+                raise Exception(f"Maximum amount to pay is {settings.mint_max_peg_out} sats "
+                                f"({invoice_amount} sats requested).")
             fees_msat = await self.check_fees(invoice)
             assert total_provided >= invoice_amount + fees_msat / 1000, Exception(
                 "provided proofs not enough for Lightning payment."

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -620,8 +620,10 @@ class Ledger:
             invoice_obj = bolt11.decode(invoice)
             invoice_amount = math.ceil(invoice_obj.amount_msat / 1000)
             if settings.mint_max_peg_out and invoice_amount > settings.mint_max_peg_out:
-                raise Exception(f"Maximum amount to pay is {settings.mint_max_peg_out} sats "
-                                f"({invoice_amount} sats requested).")
+                raise Exception(
+                    f"Maximum amount to pay is {settings.mint_max_peg_out} sats "
+                    f"({invoice_amount} sats requested)."
+                )
             fees_msat = await self.check_fees(invoice)
             assert total_provided >= invoice_amount + fees_msat / 1000, Exception(
                 "provided proofs not enough for Lightning payment."

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -104,16 +104,13 @@ async def request_mint(amount: int = 0) -> Union[GetMintResponse, CashuError]:
     """
     if settings.mint_peg_out_only:
         return CashuError(code=0, error="Mint does not allow minting new tokens.")
-    if settings.mint_max_peg_in and amount > settings.mint_max_peg_in:
-        return CashuError(
-            code=0,
-            error=f"Maximum amount to mint is {settings.mint_max_peg_in} sats "
-            f"({amount} sats requested).",
-        )
-    payment_request, hash = await ledger.request_mint(amount)
-    print(f"Lightning invoice: {payment_request}")
-    resp = GetMintResponse(pr=payment_request, hash=hash)
-    return resp
+    try:
+        payment_request, hash = await ledger.request_mint(amount)
+        print(f"Lightning invoice: {payment_request}")
+        resp = GetMintResponse(pr=payment_request, hash=hash)
+        return resp
+    except Exception as exc:
+        return CashuError(code=0, error=str(exc))
 
 
 @router.post(
@@ -133,14 +130,6 @@ async def mint(
     """
     if settings.mint_peg_out_only:
         return CashuError(code=0, error="Mint does not allow minting new tokens.")
-    if settings.mint_max_peg_in:
-        amount_requested = sum([b.amount for b in payload.outputs])
-        if amount_requested > settings.mint_max_peg_in:
-            return CashuError(
-                code=0,
-                error=f"Maximum amount to mint is {settings.mint_max_peg_in} sats "
-                f"({amount_requested} sats requested).",
-            )
     try:
         # BEGIN: backwards compatibility < 0.12 where we used to lookup payments with payment_hash
         # We use the payment_hash to lookup the hash from the database and pass that one along.

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -128,14 +128,11 @@ async def mint(
 
     Call this endpoint after `GET /mint`.
     """
-    if settings.mint_peg_out_only:
-        return CashuError(code=0, error="Mint does not allow minting new tokens.")
     try:
         # BEGIN: backwards compatibility < 0.12 where we used to lookup payments with payment_hash
         # We use the payment_hash to lookup the hash from the database and pass that one along.
         hash = payment_hash or hash
         # END: backwards compatibility < 0.12
-
         promises = await ledger.mint(payload.outputs, hash=hash)
         blinded_signatures = PostMintResponse(promises=promises)
         return blinded_signatures

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -45,10 +45,11 @@ async def info():
         contact=settings.mint_info_contact,
         nuts=settings.mint_info_nuts,
         motd=settings.mint_info_motd,
-        parameter={"max_peg_in": settings.mint_max_peg_in,
-                   "max_peg_out": settings.mint_max_peg_out,
-                   "peg_out_only": settings.mint_peg_out_only
-                   }
+        parameter={
+            "max_peg_in": settings.mint_max_peg_in,
+            "max_peg_out": settings.mint_max_peg_out,
+            "peg_out_only": settings.mint_peg_out_only,
+        },
     )
 
 
@@ -104,8 +105,11 @@ async def request_mint(amount: int = 0) -> Union[GetMintResponse, CashuError]:
     if settings.mint_peg_out_only:
         return CashuError(code=0, error="Mint does not allow minting new tokens.")
     if settings.mint_max_peg_in and amount > settings.mint_max_peg_in:
-        return CashuError(code=0, error=f"Maximum amount to mint is {settings.mint_max_peg_in} sats "
-                                        f"({amount} sats requested).")
+        return CashuError(
+            code=0,
+            error=f"Maximum amount to mint is {settings.mint_max_peg_in} sats "
+            f"({amount} sats requested).",
+        )
     payment_request, hash = await ledger.request_mint(amount)
     print(f"Lightning invoice: {payment_request}")
     resp = GetMintResponse(pr=payment_request, hash=hash)
@@ -132,8 +136,11 @@ async def mint(
     if settings.mint_max_peg_in:
         amount_requested = sum([b.amount for b in payload.outputs])
         if amount_requested > settings.mint_max_peg_in:
-            return CashuError(code=0, error=f"Maximum amount to mint is {settings.mint_max_peg_in} sats "
-                                            f"({amount_requested} sats requested).")
+            return CashuError(
+                code=0,
+                error=f"Maximum amount to mint is {settings.mint_max_peg_in} sats "
+                f"({amount_requested} sats requested).",
+            )
     try:
         # BEGIN: backwards compatibility < 0.12 where we used to lookup payments with payment_hash
         # We use the payment_hash to lookup the hash from the database and pass that one along.


### PR DESCRIPTION
Add parameter `mint_max_peg_in` and `mint_max_peg_out` to optionally limit peg in/out for mint. If set, these are added to `/info`.
Issues: closes #196