### PR TITLE
Implement dynamic amount of tokens for change

### DIFF
--- a/cashu/core/helpers.py
+++ b/cashu/core/helpers.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 from functools import partial, wraps
 from typing import List
 
@@ -42,3 +43,13 @@ def fee_reserve(amount_msat: int, internal=False) -> int:
         int(settings.lightning_reserve_fee_min),
         int(amount_msat * settings.lightning_fee_percent / 100.0),
     )
+
+
+def calculate_number_of_blank_outputs(fee_reserve_sat: int):
+    """Calculates the number of blank outputs used for returning overpaid fees.
+
+    The formula ensures that any overpaid fees can be represented by the blank outputs,
+    see NUT-08 for details.
+    """
+    assert fee_reserve_sat > 0, "Fee reserve has to be positive."
+    return max(math.ceil(math.log2(fee_reserve_sat)), 1)

--- a/cashu/wallet/api/router.py
+++ b/cashu/wallet/api/router.py
@@ -75,7 +75,7 @@ async def pay(
             status_code=status.HTTP_400_BAD_REQUEST, detail="balance is too low."
         )
     _, send_proofs = await wallet.split_to_send(wallet.proofs, total_amount)
-    await wallet.pay_lightning(send_proofs, invoice)
+    await wallet.pay_lightning(send_proofs, invoice, fee_reserve_sat)
     await wallet.load_proofs()
     return {
         "amount": total_amount - fee_reserve_sat,

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -115,7 +115,7 @@ async def pay(ctx: Context, invoice: str, yes: bool):
         print("Error: Balance too low.")
         return
     _, send_proofs = await wallet.split_to_send(wallet.proofs, total_amount)
-    await wallet.pay_lightning(send_proofs, invoice)
+    await wallet.pay_lightning(send_proofs, invoice, fee_reserve_sat)
     await wallet.load_proofs()
     wallet.status()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,7 @@
+import pytest
+
 from cashu.core.base import TokenV3
+from cashu.core.helpers import calculate_number_of_blank_outputs
 from cashu.core.split import amount_split
 
 
@@ -22,3 +25,26 @@ def test_tokenv3_deserialize_serialize():
     token_str = "cashuAeyJ0b2tlbiI6IFt7InByb29mcyI6IFt7ImlkIjogIkplaFpMVTZuQ3BSZCIsICJhbW91bnQiOiAyLCAic2VjcmV0IjogIjBFN2lDazRkVmxSZjVQRjFnNFpWMnciLCAiQyI6ICIwM2FiNTgwYWQ5NTc3OGVkNTI5NmY4YmVlNjU1ZGJkN2Q2NDJmNWQzMmRlOGUyNDg0NzdlMGI0ZDZhYTg2M2ZjZDUifSwgeyJpZCI6ICJKZWhaTFU2bkNwUmQiLCAiYW1vdW50IjogOCwgInNlY3JldCI6ICJzNklwZXh3SGNxcXVLZDZYbW9qTDJnIiwgIkMiOiAiMDIyZDAwNGY5ZWMxNmE1OGFkOTAxNGMyNTliNmQ2MTRlZDM2ODgyOWYwMmMzODc3M2M0NzIyMWY0OTYxY2UzZjIzIn1dLCAibWludCI6ICJodHRwOi8vbG9jYWxob3N0OjMzMzgifV19"
     token = TokenV3.deserialize(token_str)
     assert token.serialize() == token_str
+
+
+def test_calculate_number_of_blank_outputs():
+    # Example from NUT-08 specification.
+    fee_reserve_sat = 1000
+    expected_n_blank_outputs = 10
+    n_blank_outputs = calculate_number_of_blank_outputs(fee_reserve_sat)
+    assert n_blank_outputs == expected_n_blank_outputs
+
+
+def test_calculate_number_of_blank_outputs_for_small_fee_reserve():
+    # There should always be at least one blank output.
+    fee_reserve_sat = 1
+    expected_n_blank_outputs = 1
+    n_blank_outputs = calculate_number_of_blank_outputs(fee_reserve_sat)
+    assert n_blank_outputs == expected_n_blank_outputs
+
+
+def test_calculate_number_of_blank_outputs_fails_for_negative_fee_reserve():
+    # Negative fee reserve is not supported.
+    fee_reserve_sat = 0
+    with pytest.raises(AssertionError):
+        _ = calculate_number_of_blank_outputs(fee_reserve_sat)


### PR DESCRIPTION
With the recent update to NUT-08, we can ensure that the amount of blank outputs is always enough to cover any overpaid lightning fees. This change implements this functionality for both the wallet and the mint. The mint updateis backwards-compatible with respect to old wallets.

Closes #183