### PR TITLE
Mint API: Check `?amount` is within a sensible range

### DIFF
--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -108,6 +108,8 @@ async def request_mint(amount: int = 0) -> Union[GetMintResponse, CashuError]:
     Call `POST /mint` after paying the invoice.
     """
     logger.trace(f"> GET /mint: amount={amount}")
+    if amount > 21_000_000 * 100_000_000 or amount <= 0:
+        return CashuError(code=0, error="Amount must be a valid amount of sats.")
     if settings.mint_peg_out_only:
         return CashuError(code=0, error="Mint does not allow minting new tokens.")
     try:

--- a/tests/test_mint_api.py
+++ b/tests/test_mint_api.py
@@ -42,3 +42,15 @@ async def test_api_keyset_keys(ledger):
     assert response.json() == {
         str(k): v.serialize().hex() for k, v in ledger.keyset.public_keys.items()
     }
+
+
+@pytest.mark.asyncio
+async def test_api_mint_validation(ledger):
+    response = requests.get(f"{BASE_URL}/mint?amount=-21")
+    assert "error" in response.json()
+    response = requests.get(f"{BASE_URL}/mint?amount=0")
+    assert "error" in response.json()
+    response = requests.get(f"{BASE_URL}/mint?amount=2100000000000001")
+    assert "error" in response.json()
+    response = requests.get(f"{BASE_URL}/mint?amount=1")
+    assert "error" not in response.json()


### PR DESCRIPTION
the Mint API `/mint?amount=<int>` currently doesn't do any input validation to check that the amount is positive or a possible amount of sats (21 Quadrillion) leading to some errors downstream -- depending on the number, the DB will reject the insert query because the amount is over the maximum `INTEGER` or LNBits/Lightning Node will also reject it.