### PR TITLE
db: postgres cast int to bigint

### DIFF
--- a/cashu/core/db.py
+++ b/cashu/core/db.py
@@ -49,6 +49,12 @@ class Compat:
             return ""
         return "<nothing>"
 
+    @property
+    def big_int(self) -> str:
+        if self.type in {POSTGRES}:
+            return "BIGINT"
+        return "INT"
+
 
 class Connection(Compat):
     def __init__(self, conn: AsyncConnection, txn, typ, name, schema):

--- a/cashu/mint/migrations.py
+++ b/cashu/mint/migrations.py
@@ -16,7 +16,7 @@ async def m001_initial(db: Database):
     await db.execute(
         f"""
             CREATE TABLE IF NOT EXISTS {table_with_schema(db, 'promises')} (
-                amount INTEGER NOT NULL,
+                amount {db.big_int} NOT NULL,
                 B_b TEXT NOT NULL,
                 C_b TEXT NOT NULL,
 
@@ -29,7 +29,7 @@ async def m001_initial(db: Database):
     await db.execute(
         f"""
             CREATE TABLE IF NOT EXISTS {table_with_schema(db, 'proofs_used')} (
-                amount INTEGER NOT NULL,
+                amount {db.big_int} NOT NULL,
                 C TEXT NOT NULL,
                 secret TEXT NOT NULL,
 
@@ -42,7 +42,7 @@ async def m001_initial(db: Database):
     await db.execute(
         f"""
             CREATE TABLE IF NOT EXISTS {table_with_schema(db, 'invoices')} (
-                amount INTEGER NOT NULL,
+                amount {db.big_int} NOT NULL,
                 pr TEXT NOT NULL,
                 hash TEXT NOT NULL,
                 issued BOOL NOT NULL,

--- a/cashu/wallet/migrations.py
+++ b/cashu/wallet/migrations.py
@@ -14,9 +14,9 @@ async def m000_create_migrations_table(db: Database):
 
 async def m001_initial(db: Database):
     await db.execute(
-        """
+        f"""
             CREATE TABLE IF NOT EXISTS proofs (
-                amount INTEGER NOT NULL,
+                amount {db.big_int} NOT NULL,
                 C TEXT NOT NULL,
                 secret TEXT NOT NULL,
 
@@ -27,9 +27,9 @@ async def m001_initial(db: Database):
     )
 
     await db.execute(
-        """
+        f"""
             CREATE TABLE IF NOT EXISTS proofs_used (
-                amount INTEGER NOT NULL,
+                amount {db.big_int} NOT NULL,
                 C TEXT NOT NULL,
                 secret TEXT NOT NULL,
 


### PR DESCRIPTION
Postgres compatibility: Cast columns of type `INT` to `BIGINT`. Closes #228