### PR TITLE
Add secp256k1 deps to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM python:3.9-slim
 RUN apt-get update
 RUN apt-get install -y curl python3-dev autoconf g++
 RUN apt-get install -y libpq-dev
+
+# Deps for building secp256k1-py
+RUN apt-get install -y build-essential automake pkg-config libtool libffi-dev
+
 RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="/root/.local/bin:$PATH"
 WORKDIR /app


### PR DESCRIPTION
The dockerfile was failing to build because it was missing some dependencies needed by https://github.com/rustyrussell/secp256k1-py

To test:
```
docker build .
```