### PR TITLE
[Wallet] send without split

### DIFF
--- a/cashu/wallet/api/router.py
+++ b/cashu/wallet/api/router.py
@@ -166,13 +166,16 @@ async def send_command(
         default=None,
         description="Mint URL to send from (None for default mint)",
     ),
+    nosplit: bool = Query(
+        default=False, description="Do not split tokens before sending."
+    ),
 ):
     global wallet
-    wallet = await load_mint(wallet, mint)
-
     await wallet.load_proofs()
     if not nostr:
-        balance, token = await send(wallet, amount, lock, legacy=False)
+        balance, token = await send(
+            wallet, amount, lock, legacy=False, split=not nosplit
+        )
         return SendResponse(balance=balance, token=token)
     else:
         token, pubkey = await send_nostr(wallet, amount, nostr)

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -275,6 +275,14 @@ async def balance(ctx: Context, verbose):
 @click.option(
     "--yes", "-y", default=False, is_flag=True, help="Skip confirmation.", type=bool
 )
+@click.option(
+    "--nosplit",
+    "-s",
+    default=False,
+    is_flag=True,
+    help="Do not split tokens before sending.",
+    type=bool,
+)
 @click.pass_context
 @coro
 async def send_command(
@@ -286,10 +294,11 @@ async def send_command(
     legacy: bool,
     verbose: bool,
     yes: bool,
+    nosplit: bool,
 ):
     wallet: Wallet = ctx.obj["WALLET"]
     if not nostr and not nopt:
-        await send(wallet, amount, lock, legacy)
+        await send(wallet, amount, lock, legacy, split=not nosplit)
     else:
         await send_nostr(wallet, amount, nostr or nopt, verbose, yes)
 

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -5,7 +5,7 @@ import secrets as scrts
 import time
 import uuid
 from itertools import groupby
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import requests
 from loguru import logger
@@ -355,7 +355,7 @@ class LedgerAPI:
 
         If scnd_secret is provided, the wallet will create blinded secrets with those to attach a
         predefined spending condition to the tokens they want to send."""
-
+        logger.debug("Calling split. POST /split")
         total = sum_proofs(proofs)
         frst_amt, scnd_amt = total - amount, amount
         frst_outputs = amount_split(frst_amt)
@@ -852,14 +852,6 @@ class Wallet(LedgerAPI):
         logger.debug(f"Mint wants {fees} sat as fee reserve.")
         amount = math.ceil((decoded_invoice.amount_msat + fees * 1000) / 1000)  # 1% fee
         return amount, fees
-
-    async def split_to_pay(self, invoice: str):
-        """
-        Splits proofs such that a Lightning invoice can be paid.
-        """
-        amount, _ = await self.get_pay_amount_with_fees(invoice)
-        _, send_proofs = await self.split_to_send(self.proofs, amount)
-        return send_proofs
 
     async def split_to_send(
         self,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -121,7 +121,7 @@ def test_send_without_split(mint, cli_prefix):
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        [*cli_prefix, "send", "1", "--nosplit"],
+        [*cli_prefix, "send", "2", "--nosplit"],
     )
     assert result.exception is None
     print("SEND")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,6 +117,29 @@ def test_send(mint, cli_prefix):
 
 
 @pytest.mark.asyncio
+def test_send_without_split(mint, cli_prefix):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "send", "1", "--nosplit"],
+    )
+    assert result.exception is None
+    print("SEND")
+    print(result.output)
+    assert "cashuA" in result.output, "output does not have a token"
+
+
+@pytest.mark.asyncio
+def test_send_without_split_but_wrong_amount(mint, cli_prefix):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "send", "10", "--nosplit"],
+    )
+    assert "No proof with this amount found" in str(result.exception)
+
+
+@pytest.mark.asyncio
 def test_receive_tokenv3(mint, cli_prefix):
     runner = CliRunner()
     token = "cashuAeyJ0b2tlbiI6IFt7InByb29mcyI6IFt7ImlkIjogIjFjQ05JQVoyWC93MSIsICJhbW91bnQiOiAyLCAic2VjcmV0IjogIld6TEF2VW53SDlRaFYwQU1rMy1oYWciLCAiQyI6ICIwMmZlMzUxYjAyN2FlMGY1ZDkyN2U2ZjFjMTljMjNjNTc3NzRhZTI2M2UyOGExN2E2MTUxNjY1ZjU3NWNhNjMyNWMifSwgeyJpZCI6ICIxY0NOSUFaMlgvdzEiLCAiYW1vdW50IjogOCwgInNlY3JldCI6ICJDamFTeTcyR2dVOGwzMGV6bE5zZnVBIiwgIkMiOiAiMDNjMzM0OTJlM2ZlNjI4NzFhMWEzMDhiNWUyYjVhZjBkNWI1Mjk5YzI0YmVkNDI2ZjQ1YzZmNDg5N2QzZjc4NGQ5In1dLCAibWludCI6ICJodHRwOi8vbG9jYWxob3N0OjMzMzcifV19"

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -57,6 +57,19 @@ def test_send(mint):
         assert response.json()["balance"]
 
 
+def test_send_without_split(mint):
+    with TestClient(app) as client:
+        response = client.post("/send?amount=1&nosplit=true")
+        assert response.status_code == 200
+        assert response.json()["balance"]
+
+
+def test_send_without_split_but_wrong_amount(mint):
+    with TestClient(app) as client:
+        response = client.post("/send?amount=10&nosplit=true")
+        assert response.status_code == 400
+
+
 def test_pending():
     with TestClient(app) as client:
         response = client.get("/pending")


### PR DESCRIPTION
Sending tokens that are already available without doing a `/split`. Available in the wallet CLI and API.