### PR TITLE
[Wallet/mint] P2PK with timelocks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ TOR=TRUE
 
 # NOSTR
 # nostr private key to which to receive tokens to
-NOSTR_PRIVATE_KEY=nostr_privatekey_here_hex_or_bech32
+NOSTR_PRIVATE_KEY=nostr_privatekey_here_hex_or_bech32_nsec
 # nostr relays (comma separated list)
 NOSTR_RELAYS=["wss://nostr-pub.wellorder.net"]
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ cashu info
 
 Returns:
 ```bash
-Version: 0.12.1
+Version: 0.12.2
 Debug: False
 Cashu dir: /home/user/.cashu
 Wallet: wallet

--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -29,16 +29,16 @@ class Secret(BaseModel):
     tags: Union[None, List[List[str]]] = None
 
     def serialize(self) -> str:
+        data_dict: Dict[str, Any] = {
+            "data": self.data,
+            "nonce": self.nonce or PrivateKey().serialize()[:32],
+        }
+        if self.timelock:
+            data_dict["timelock"] = self.timelock
+        if self.tags:
+            data_dict["tags"] = self.tags
         return json.dumps(
-            [
-                self.kind,
-                {
-                    "data": self.data,
-                    "nonce": self.nonce or PrivateKey().serialize()[:32],
-                    "timelock": self.timelock,
-                    "tags": self.tags,
-                },
-            ]
+            [self.kind, data_dict],
         )
 
     @classmethod

--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -34,6 +34,7 @@ class Proof(BaseModel):
     amount: int = 0
     secret: str = ""  # secret or message to be blinded and signed
     C: str = ""  # signature on secret, unblinded by wallet
+    p2pksig: Optional[str] = None  # P2PK signature
     script: Union[P2SHScript, None] = None  # P2SH spending condition
     reserved: Union[
         None, bool

--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -37,6 +37,11 @@ class Secret(BaseModel):
             data_dict["timelock"] = self.timelock
         if self.tags:
             data_dict["tags"] = self.tags
+        logger.debug(
+            json.dumps(
+                [self.kind, data_dict],
+            )
+        )
         return json.dumps(
             [self.kind, data_dict],
         )

--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from .crypto.keys import derive_keys, derive_keyset_id, derive_pubkeys
 from .crypto.secp import PrivateKey, PublicKey
 from .legacy import derive_keys_backwards_compatible_insecure_pre_0_12
+from .p2pk import sign_p2pk_sign
 
 # ------- PROOFS -------
 
@@ -175,6 +176,19 @@ class PostSplitRequest(BaseModel):
     proofs: List[Proof]
     amount: int
     outputs: List[BlindedMessage]
+    signature: Optional[str] = None
+
+    def sign(self, private_key: PrivateKey):
+        """
+        Create a signed split request. The signature is over the `proofs` and `outputs` fields.
+        """
+        # message = json.dumps(self.proofs).encode("utf-8") + json.dumps(
+        #     self.outputs
+        # ).encode("utf-8")
+        message = json.dumps(self.dict(include={"proofs": ..., "outputs": ...})).encode(
+            "utf-8"
+        )
+        self.signature = sign_p2pk_sign(message, private_key)
 
 
 class PostSplitResponse(BaseModel):

--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -19,6 +19,16 @@ class SecretKind:
     P2PK = "P2PK"
 
 
+class Tags(BaseModel):
+    __root__: List[List[str]]
+
+    def get_tag(self, tag_name: str) -> Union[str, None]:
+        for tag in self.__root__:
+            if tag[0] == tag_name:
+                return tag[1]
+        return None
+
+
 class Secret(BaseModel):
     """Describes spending condition encoded in the secret field of a Proof."""
 
@@ -26,7 +36,7 @@ class Secret(BaseModel):
     data: str
     nonce: Union[None, str] = None
     timelock: Union[None, int] = None
-    tags: Union[None, List[List[str]]] = None
+    tags: Union[None, Tags] = None
 
     def serialize(self) -> str:
         data_dict: Dict[str, Any] = {
@@ -36,7 +46,7 @@ class Secret(BaseModel):
         if self.timelock:
             data_dict["timelock"] = self.timelock
         if self.tags:
-            data_dict["tags"] = self.tags
+            data_dict["tags"] = self.tags.__root__
         logger.debug(
             json.dumps(
                 [self.kind, data_dict],

--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -176,19 +176,19 @@ class PostSplitRequest(BaseModel):
     proofs: List[Proof]
     amount: int
     outputs: List[BlindedMessage]
-    signature: Optional[str] = None
+    # signature: Optional[str] = None
 
-    def sign(self, private_key: PrivateKey):
-        """
-        Create a signed split request. The signature is over the `proofs` and `outputs` fields.
-        """
-        # message = json.dumps(self.proofs).encode("utf-8") + json.dumps(
-        #     self.outputs
-        # ).encode("utf-8")
-        message = json.dumps(self.dict(include={"proofs": ..., "outputs": ...})).encode(
-            "utf-8"
-        )
-        self.signature = sign_p2pk_sign(message, private_key)
+    # def sign(self, private_key: PrivateKey):
+    #     """
+    #     Create a signed split request. The signature is over the `proofs` and `outputs` fields.
+    #     """
+    #     # message = json.dumps(self.proofs).encode("utf-8") + json.dumps(
+    #     #     self.outputs
+    #     # ).encode("utf-8")
+    #     message = json.dumps(self.dict(include={"proofs": ..., "outputs": ...})).encode(
+    #         "utf-8"
+    #     )
+    #     self.signature = sign_p2pk_sign(message, private_key)
 
 
 class PostSplitResponse(BaseModel):

--- a/cashu/core/p2pk.py
+++ b/cashu/core/p2pk.py
@@ -1,0 +1,33 @@
+import hashlib
+
+from cashu.core.crypto.secp import PrivateKey, PublicKey
+
+
+def sign_p2pk_pubkey(private_key: PrivateKey):
+    assert private_key.pubkey
+    message = private_key.pubkey.serialize()
+    signature = private_key.ecdsa_serialize(private_key.ecdsa_sign(message))
+    return signature.hex()
+
+
+def verify_p2pk_signature(message: bytes, pubkey: PublicKey, signature: bytes):
+    return pubkey.ecdsa_verify(message, pubkey_verify.ecdsa_deserialize(signature))
+
+
+if __name__ == "__main__":
+    # generate keys
+    private_key_bytes = b"12300000000000000000000000000123"
+    private_key = PrivateKey(private_key_bytes, raw=True)
+    print(private_key.serialize())
+    public_key = private_key.pubkey
+    assert public_key
+    print(public_key.serialize().hex())
+
+    # sign message (=pubkey)
+    message = public_key.serialize()
+    signature = private_key.ecdsa_serialize(private_key.ecdsa_sign(message))
+    print(signature.hex())
+
+    # verify
+    pubkey_verify = PublicKey(message, raw=True)
+    print(public_key.ecdsa_verify(message, pubkey_verify.ecdsa_deserialize(signature)))

--- a/cashu/core/p2pk.py
+++ b/cashu/core/p2pk.py
@@ -4,12 +4,16 @@ from cashu.core.crypto.secp import PrivateKey, PublicKey
 
 
 def sign_p2pk_sign(message: bytes, private_key: PrivateKey):
-    signature = private_key.ecdsa_serialize(private_key.ecdsa_sign(message))
+    # ecdsa version
+    # signature = private_key.ecdsa_serialize(private_key.ecdsa_sign(message))
+    signature = private_key.schnorr_sign(message, None, raw=True)
     return signature.hex()
 
 
 def verify_p2pk_signature(message: bytes, pubkey: PublicKey, signature: bytes):
-    return pubkey.ecdsa_verify(message, pubkey.ecdsa_deserialize(signature))
+    # ecdsa version
+    # return pubkey.ecdsa_verify(message, pubkey.ecdsa_deserialize(signature))
+    return pubkey.schnorr_verify(message, signature, None, raw=True)
 
 
 if __name__ == "__main__":

--- a/cashu/core/p2pk.py
+++ b/cashu/core/p2pk.py
@@ -9,7 +9,7 @@ def sign_p2pk_sign(message: bytes, private_key: PrivateKey):
 
 
 def verify_p2pk_signature(message: bytes, pubkey: PublicKey, signature: bytes):
-    return pubkey.ecdsa_verify(message, pubkey_verify.ecdsa_deserialize(signature))
+    return pubkey.ecdsa_verify(message, pubkey.ecdsa_deserialize(signature))
 
 
 if __name__ == "__main__":

--- a/cashu/core/p2pk.py
+++ b/cashu/core/p2pk.py
@@ -1,17 +1,23 @@
+import hashlib
+
 from cashu.core.crypto.secp import PrivateKey, PublicKey
 
 
 def sign_p2pk_sign(message: bytes, private_key: PrivateKey):
     # ecdsa version
     # signature = private_key.ecdsa_serialize(private_key.ecdsa_sign(message))
-    signature = private_key.schnorr_sign(message, None, raw=True)
+    signature = private_key.schnorr_sign(
+        hashlib.sha256(message).digest(), None, raw=True
+    )
     return signature.hex()
 
 
 def verify_p2pk_signature(message: bytes, pubkey: PublicKey, signature: bytes):
     # ecdsa version
     # return pubkey.ecdsa_verify(message, pubkey.ecdsa_deserialize(signature))
-    return pubkey.schnorr_verify(message, signature, None, raw=True)
+    return pubkey.schnorr_verify(
+        hashlib.sha256(message).digest(), signature, None, raw=True
+    )
 
 
 if __name__ == "__main__":

--- a/cashu/core/p2pk.py
+++ b/cashu/core/p2pk.py
@@ -3,9 +3,7 @@ import hashlib
 from cashu.core.crypto.secp import PrivateKey, PublicKey
 
 
-def sign_p2pk_pubkey(private_key: PrivateKey):
-    assert private_key.pubkey
-    message = private_key.pubkey.serialize()
+def sign_p2pk_sign(message: bytes, private_key: PrivateKey):
     signature = private_key.ecdsa_serialize(private_key.ecdsa_sign(message))
     return signature.hex()
 

--- a/cashu/core/p2pk.py
+++ b/cashu/core/p2pk.py
@@ -1,5 +1,3 @@
-import hashlib
-
 from cashu.core.crypto.secp import PrivateKey, PublicKey
 
 

--- a/cashu/core/script.py
+++ b/cashu/core/script.py
@@ -79,28 +79,28 @@ def step3_bob_verify_script(txin_signature, txin_redeemScript, tx):
         raise Exception("Script execution failed:", e)
 
 
-def verify_script(txin_redeemScript_b64, txin_signature_b64):
+def verify_bitcoin_script(txin_redeemScript_b64, txin_signature_b64):
     txin_redeemScript = CScript(base64.urlsafe_b64decode(txin_redeemScript_b64))
-    print("Redeem script:", txin_redeemScript.__repr__())
+    # print("Redeem script:", txin_redeemScript.__repr__())
     # txin_redeemScript = CScript([2, 3, OP_LESSTHAN, OP_VERIFY])
     txin_signature = CScript(value=base64.urlsafe_b64decode(txin_signature_b64))
 
     txin_p2sh_address = step1_carol_create_p2sh_address(txin_redeemScript)
-    print(f"Bob recreates secret: P2SH:{txin_p2sh_address}")
+    # print(f"Bob recreates secret: P2SH:{txin_p2sh_address}")
     # MINT checks that P2SH:txin_p2sh_address has not been spent yet
     # ...
     tx, _ = step1_bob_carol_create_tx(txin_p2sh_address)
 
-    print(
-        f"Bob verifies:\nscript: {txin_redeemScript_b64}\nsignature: {txin_signature_b64}\n"
-    )
+    # print(
+    #     f"Bob verifies:\nscript: {txin_redeemScript_b64}\nsignature: {txin_signature_b64}\n"
+    # )
     script_valid = step3_bob_verify_script(txin_signature, txin_redeemScript, tx)
     # MINT redeems tokens and stores P2SH:txin_p2sh_address
     # ...
-    if script_valid:
-        print("Successfull.")
-    else:
-        print("Error.")
+    # if script_valid:
+    # print("Successfull.")
+    # else:
+    # print("Error.")
     return txin_p2sh_address, script_valid
 
 

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -8,7 +8,7 @@ from pydantic import BaseSettings, Extra, Field
 
 env = Env()
 
-VERSION = "0.12.1"
+VERSION = "0.12.2"
 
 
 def find_env_file():

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -98,7 +98,7 @@ class WalletSettings(CashuSettings):
         ]
     )
 
-    timelock_delta_seconds: int = Field(default=86400)
+    timelock_delta_seconds: int = Field(default=86400)  # 1 day
 
 
 class Settings(

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -98,9 +98,15 @@ class WalletSettings(CashuSettings):
         ]
     )
 
+    timelock_delta_seconds: int = Field(default=86400)
+
 
 class Settings(
-    EnvSettings, MintSettings, MintInformation, WalletSettings, CashuSettings
+    EnvSettings,
+    MintSettings,
+    MintInformation,
+    WalletSettings,
+    CashuSettings,
 ):
     version: str = Field(default=VERSION)
 

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -211,7 +211,7 @@ class Ledger:
         C = PublicKey(bytes.fromhex(proof.C), raw=True)
         return b_dhke.verify(private_key_amount, C, proof.secret)
 
-    def _verify_script(self, idx: int, proof: Proof) -> bool:
+    def _verify_script(self, proof: Proof) -> bool:
         """
         Verify bitcoin script in proof.script commited to by <address> in proof.secret.
 
@@ -547,7 +547,7 @@ class Ledger:
             Exception: BDHKE verification failed.
         """
         # Verify scripts
-        if not all([self._verify_script(i, p) for i, p in enumerate(proofs)]):
+        if not all([self._verify_script(p) for p in proofs]):
             raise Exception("script validation failed.")
         # Verify secret criteria
         if not all([self._verify_secret_criteria(p) for p in proofs]):

--- a/cashu/wallet/api/router.py
+++ b/cashu/wallet/api/router.py
@@ -220,7 +220,6 @@ async def send_command(
 @router.post("/receive", name="Receive tokens", response_model=ReceiveResponse)
 async def receive_command(
     token: str = Query(default=None, description="Token to receive"),
-    lock: str = Query(default=None, description="Unlock tokens"),
     nostr: bool = Query(default=False, description="Receive tokens via nostr"),
     all: bool = Query(default=False, description="Receive all pending tokens"),
 ):
@@ -228,7 +227,7 @@ async def receive_command(
     if token:
         tokenObj: TokenV3 = deserialize_token_from_string(token)
         await verify_mints(wallet, tokenObj)
-        balance = await receive(wallet, tokenObj, lock)
+        balance = await receive(wallet, tokenObj)
     elif nostr:
         await receive_nostr(wallet)
         balance = wallet.available_balance
@@ -241,7 +240,7 @@ async def receive_command(
                 token = await wallet.serialize_proofs(proofs)
                 tokenObj = deserialize_token_from_string(token)
                 await verify_mints(wallet, tokenObj)
-                balance = await receive(wallet, tokenObj, lock)
+                balance = await receive(wallet, tokenObj)
     else:
         raise Exception("enter token or use either flag --nostr or --all.")
     assert balance

--- a/cashu/wallet/api/router.py
+++ b/cashu/wallet/api/router.py
@@ -336,9 +336,8 @@ async def pending(
 
 @router.get("/lock", name="Generate receiving lock", response_model=LockResponse)
 async def lock():
-    p2shscript = await wallet.create_p2sh_lock()
-    txin_p2sh_address = p2shscript.address
-    return LockResponse(P2SH=txin_p2sh_address)
+    address = await wallet.create_p2sh_address_and_store()
+    return LockResponse(P2SH=address)
 
 
 @router.get("/locks", name="Show unused receiving locks", response_model=LocksResponse)

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -513,26 +513,26 @@ async def pending(ctx: Context, legacy, number: int, offset: int):
 
 @cli.command("lock", help="Generate receiving lock.")
 @click.option(
-    "--p2pk",
+    "--p2sh",
     "-p",
     default=False,
     is_flag=True,
-    help="Create P2PK lock.",
+    help="Create P2SH lock.",
     type=bool,
 )
 @click.pass_context
 @coro
-async def lock(ctx, p2pk):
+async def lock(ctx, p2sh):
     wallet: Wallet = ctx.obj["WALLET"]
-    if p2pk:
-        pubkey = await wallet.create_p2pk_lock()
-        lock_str = f"P2PK:{pubkey}"
-        print("---- Pay to public key (P2PK) ----\n")
-    else:
+    if p2sh:
         p2shscript = await wallet.create_p2sh_lock()
         txin_p2sh_address = p2shscript.address
         lock_str = f"P2SH:{txin_p2sh_address}"
         print("---- Pay to script hash (P2SH) ----\n")
+    else:
+        pubkey = await wallet.create_p2pk_lock()
+        lock_str = f"P2PK:{pubkey}"
+        print("---- Pay to public key (P2PK) ----\n")
 
     print("Use a lock to receive tokens that only you can unlock.")
     print("")
@@ -550,12 +550,18 @@ async def lock(ctx, p2pk):
 @coro
 async def locks(ctx):
     wallet: Wallet = ctx.obj["WALLET"]
+    # P2PK lock
+    pubkey = await wallet.create_p2pk_lock()
+    lock_str = f"P2PK:{pubkey}"
+    print("---- Pay to public key (P2PK) lock ----\n")
+    print(f"Lock: {lock_str}")
+    # P2SH locks
     locks = await get_unused_locks(db=wallet.db)
     if len(locks):
         print("")
-        print(f"--------------------------\n")
+        print("---- Pay to script hash (P2SH) locks ----\n")
         for l in locks:
-            print(f"Address: {l.address}")
+            print(f"Lock: P2SH:{l.address}")
             print(f"Script: {l.script}")
             print(f"Signature: {l.signature}")
             print("")

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -353,14 +353,6 @@ async def send_command(
 @click.option(
     "--all", "-a", default=False, is_flag=True, help="Receive all pending tokens."
 )
-@click.option(
-    "--verbose",
-    "-v",
-    help="Display more information.",
-    is_flag=True,
-    default=False,
-    type=bool,
-)
 @click.pass_context
 @coro
 async def receive_cli(
@@ -368,7 +360,6 @@ async def receive_cli(
     token: str,
     nostr: bool,
     all: bool,
-    verbose: bool,
 ):
     wallet: Wallet = ctx.obj["WALLET"]
 
@@ -384,7 +375,7 @@ async def receive_cli(
 
         await receive(wallet, tokenObj)
     elif nostr:
-        await receive_nostr(wallet, verbose)
+        await receive_nostr(wallet)
     elif all:
         reserved_proofs = await get_reserved_proofs(wallet.db)
         if len(reserved_proofs):

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -525,12 +525,11 @@ async def pending(ctx: Context, legacy, number: int, offset: int):
 async def lock(ctx, p2sh):
     wallet: Wallet = ctx.obj["WALLET"]
     if p2sh:
-        p2shscript = await wallet.create_p2sh_lock()
-        txin_p2sh_address = p2shscript.address
-        lock_str = f"P2SH:{txin_p2sh_address}"
+        address = await wallet.create_p2sh_address_and_store()
+        lock_str = f"P2SH:{address}"
         print("---- Pay to script hash (P2SH) ----\n")
     else:
-        pubkey = await wallet.create_p2pk_lock()
+        pubkey = await wallet.create_p2pk_pubkey()
         lock_str = f"P2PK:{pubkey}"
         print("---- Pay to public key (P2PK) ----\n")
 
@@ -551,7 +550,7 @@ async def lock(ctx, p2sh):
 async def locks(ctx):
     wallet: Wallet = ctx.obj["WALLET"]
     # P2PK lock
-    pubkey = await wallet.create_p2pk_lock()
+    pubkey = await wallet.create_p2pk_pubkey()
     lock_str = f"P2PK:{pubkey}"
     print("---- Pay to public key (P2PK) lock ----\n")
     print(f"Lock: {lock_str}")

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -347,7 +347,6 @@ async def send_command(
 
 @cli.command("receive", help="Receive tokens.")
 @click.argument("token", type=str, default="")
-@click.option("--lock", "-l", default=None, help="Unlock tokens.", type=str)
 @click.option(
     "--nostr", "-n", default=False, is_flag=True, help="Receive tokens via nostr."
 )
@@ -367,13 +366,11 @@ async def send_command(
 async def receive_cli(
     ctx: Context,
     token: str,
-    lock: str,
     nostr: bool,
     all: bool,
     verbose: bool,
 ):
     wallet: Wallet = ctx.obj["WALLET"]
-    wallet.status()
 
     if token:
         tokenObj = deserialize_token_from_string(token)
@@ -385,7 +382,7 @@ async def receive_cli(
             )
             await verify_mint(mint_wallet, mint_url)
 
-        await receive(wallet, tokenObj, lock)
+        await receive(wallet, tokenObj)
     elif nostr:
         await receive_nostr(wallet, verbose)
     elif all:
@@ -402,7 +399,7 @@ async def receive_cli(
                         mint_url, os.path.join(settings.cashu_dir, wallet.name)
                     )
                     await verify_mint(mint_wallet, mint_url)
-                await receive(wallet, tokenObj, lock)
+                await receive(wallet, tokenObj)
     else:
         print("Error: enter token or use either flag --nostr or --all.")
 
@@ -515,24 +512,37 @@ async def pending(ctx: Context, legacy, number: int, offset: int):
 
 
 @cli.command("lock", help="Generate receiving lock.")
+@click.option(
+    "--p2pk",
+    "-p",
+    default=False,
+    is_flag=True,
+    help="Create P2PK lock.",
+    type=bool,
+)
 @click.pass_context
 @coro
-async def lock(ctx):
+async def lock(ctx, p2pk):
     wallet: Wallet = ctx.obj["WALLET"]
-    p2shscript = await wallet.create_p2sh_lock()
-    txin_p2sh_address = p2shscript.address
-    print("---- Pay to script hash (P2SH) ----\n")
+    if p2pk:
+        pubkey = await wallet.create_p2pk_lock()
+        lock_str = f"P2PK:{pubkey}"
+        print("---- Pay to public key (P2PK) ----\n")
+    else:
+        p2shscript = await wallet.create_p2sh_lock()
+        txin_p2sh_address = p2shscript.address
+        lock_str = f"P2SH:{txin_p2sh_address}"
+        print("---- Pay to script hash (P2SH) ----\n")
+
     print("Use a lock to receive tokens that only you can unlock.")
     print("")
-    print(f"Public receiving lock: P2SH:{txin_p2sh_address}")
+    print(f"Public receiving lock: {lock_str}")
     print("")
     print(
-        f"Anyone can send tokens to this lock:\n\ncashu send <amount> --lock P2SH:{txin_p2sh_address}"
+        f"Anyone can send tokens to this lock:\n\ncashu send <amount> --lock {lock_str}"
     )
     print("")
-    print(
-        f"Only you can receive tokens from this lock:\n\ncashu receive <token> --lock P2SH:{txin_p2sh_address}\n"
-    )
+    print(f"Only you can receive tokens from this lock: cashu receive <token>")
 
 
 @cli.command("locks", help="Show unused receiving locks.")
@@ -548,8 +558,6 @@ async def locks(ctx):
             print(f"Address: {l.address}")
             print(f"Script: {l.script}")
             print(f"Signature: {l.signature}")
-            print("")
-            print(f"Receive: cashu receive <token> --lock P2SH:{l.address}")
             print("")
             print(f"--------------------------\n")
     else:

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -348,7 +348,11 @@ async def send_command(
 @cli.command("receive", help="Receive tokens.")
 @click.argument("token", type=str, default="")
 @click.option(
-    "--nostr", "-n", default=False, is_flag=True, help="Receive tokens via nostr."
+    "--nostr",
+    "-n",
+    default=False,
+    is_flag=True,
+    help="Receive tokens via nostr." "receive",
 )
 @click.option(
     "--all", "-a", default=False, is_flag=True, help="Receive all pending tokens."

--- a/cashu/wallet/helpers.py
+++ b/cashu/wallet/helpers.py
@@ -109,6 +109,7 @@ async def receive(
     wallet: Wallet,
     tokenObj: TokenV3,
 ):
+    logger.debug(f"receive: {tokenObj}")
     proofs = [p for t in tokenObj.token for p in t.proofs]
 
     includes_mint_info: bool = any([t.mint for t in tokenObj.token])

--- a/cashu/wallet/helpers.py
+++ b/cashu/wallet/helpers.py
@@ -185,14 +185,25 @@ async def send(
             raise Exception("Error: lock has to start with P2SH: or P2PK:")
         # we add a time lock to the P2PK lock by appending the current unix time + 14 days
         # we use datetime because it's easier to read
-        if lock.startswith("P2PK:"):
+        if lock.startswith("P2PK:") or lock.startswith("P2SH:"):
+            logger.debug(f"Locking token to: {lock}")
+            logger.debug(
+                f"Adding a time lock of {settings.timelock_delta_seconds} seconds."
+            )
             lock = (
                 lock
                 + ":"
-                + str(int((datetime.now() + timedelta(hours=24)).timestamp()))
+                + str(
+                    int(
+                        (
+                            datetime.now()
+                            + timedelta(seconds=settings.timelock_delta_seconds)
+                        ).timestamp()
+                    )
+                )
             )
-            # we also add some op_return data to the P2PK lock
-            lock += ":additional_commitmens"
+            # we can also add some op_return data to the lock just for fun
+            lock += ":rekt"
 
     await wallet.load_proofs()
     if split:

--- a/cashu/wallet/nostr.py
+++ b/cashu/wallet/nostr.py
@@ -123,7 +123,6 @@ async def receive_nostr(
                 receive(
                     wallet,
                     decrypted_content,
-                    "",
                 )
             )
         except Exception as e:

--- a/cashu/wallet/nostr.py
+++ b/cashu/wallet/nostr.py
@@ -11,7 +11,7 @@ from ..nostr.nostr.client.client import NostrClient
 from ..nostr.nostr.event import Event
 from ..nostr.nostr.key import PublicKey
 from .crud import get_nostr_last_check_timestamp, set_nostr_last_check_timestamp
-from .helpers import receive, deserialize_token_from_string
+from .helpers import deserialize_token_from_string, receive
 from .wallet import Wallet
 
 

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -1092,7 +1092,8 @@ class Wallet(LedgerAPI):
         assert private_key.pubkey
         return [
             sign_p2pk_sign(
-                message=proof.secret.encode("utf-8"), private_key=private_key
+                message=proof.secret.encode("utf-8"),
+                private_key=private_key,
             )
             for proof in proofs
         ]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ entry_points = {"console_scripts": ["cashu = cashu.wallet.cli.cli:cli"]}
 
 setuptools.setup(
     name="cashu",
-    version="0.12.1",
+    version="0.12.2",
     description="Ecash wallet and mint for Bitcoin Lightning",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import os
+import secrets
 import shutil
 import time
 from pathlib import Path
@@ -58,6 +59,7 @@ def mint():
     settings.port = 3337
     settings.mint_url = "http://localhost:3337"
     settings.port = settings.mint_listen_port
+    settings.nostr_private_key = secrets.token_hex(32)  # wrong private key
     config = uvicorn.Config(
         "cashu.mint.app:app",
         port=settings.mint_listen_port,

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -277,7 +277,9 @@ async def no_test_p2sh(wallet1: Wallet, wallet2: Wallet):
     assert send_proofs[0].secret.startswith("P2SH:")
 
     frst_proofs, scnd_proofs = await wallet2.redeem(
-        send_proofs, scnd_script=p2shscript.script, scnd_siganture=p2shscript.signature
+        send_proofs,
+        secret_lock_script=p2shscript.script,
+        secret_lock_signature=p2shscript.signature,
     )
     assert len(frst_proofs) == 0
     assert len(scnd_proofs) == 1
@@ -298,7 +300,9 @@ async def test_p2sh_receive_wrong_script(wallet1: Wallet, wallet2: Wallet):
 
     await assert_err(
         wallet2.redeem(
-            send_proofs, scnd_script=wrong_script, scnd_siganture=p2shscript.signature
+            send_proofs,
+            secret_lock_script=wrong_script,
+            secret_lock_signature=p2shscript.signature,
         ),
         "Mint Error: ('Script verification failed:', VerifyScriptError('scriptPubKey returned false'))",
     )
@@ -318,7 +322,9 @@ async def test_p2sh_receive_wrong_signature(wallet1: Wallet, wallet2: Wallet):
 
     await assert_err(
         wallet2.redeem(
-            send_proofs, scnd_script=p2shscript.script, scnd_siganture=wrong_signature
+            send_proofs,
+            secret_lock_script=p2shscript.script,
+            secret_lock_signature=wrong_signature,
         ),
         "Mint Error: ('Script evaluation failed:', EvalScriptError('EvalScript: OP_RETURN called'))",
     )

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -248,8 +248,10 @@ async def test_split_with_secret(wallet1: Wallet):
     w1_frst_proofs, w1_scnd_proofs = await wallet1.split(
         wallet1.proofs, 32, secret_lock=secret
     )
-    # check if index prefix is in secret
-    assert w1_scnd_proofs[0].secret == "0:" + secret
+    # check if secret is in the proofs to send
+    assert w1_scnd_proofs[0].secret.startswith(secret)
+    # check if secret is not in the proofs to keep
+    assert not w1_frst_proofs[0].secret.startswith(secret)
 
 
 @pytest.mark.asyncio

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -298,6 +298,52 @@ async def test_p2pk_short_timelock_receive_with_wrong_private_key(
 
 
 @pytest.mark.asyncio
+async def test_p2pk_timelock_with_refund_pubkey(wallet1: Wallet, wallet2: Wallet):
+    await wallet1.mint(64)
+    pubkey_wallet2 = await wallet2.create_p2pk_pubkey()  # receiver side
+    # sender side
+    garbage_pubkey = PrivateKey().pubkey
+    assert garbage_pubkey
+    secret_lock = await wallet1.create_p2pk_lock(
+        garbage_pubkey.serialize().hex(),  # create lock to unspendable pubkey
+        timelock=4,  # timelock
+        tags=[["refund", pubkey_wallet2]],  # refund pubkey
+    )  # sender side
+    _, send_proofs = await wallet1.split_to_send(
+        wallet1.proofs, 8, secret_lock=secret_lock
+    )
+    # receiver side: can't redeem since we used a garbage pubkey
+    await assert_err(wallet2.redeem(send_proofs), "Mint Error: p2pk signature invalid.")
+    await asyncio.sleep(6)
+    # we can now redeem because of the refund timelock
+    await wallet2.redeem(send_proofs)
+
+
+@pytest.mark.asyncio
+async def test_p2pk_timelock_with_wrong_refund_pubkey(wallet1: Wallet, wallet2: Wallet):
+    await wallet1.mint(64)
+    pubkey_wallet2 = await wallet2.create_p2pk_pubkey()  # receiver side
+    # sender side
+    garbage_pubkey = PrivateKey().pubkey
+    garbage_pubkey_2 = PrivateKey().pubkey
+    assert garbage_pubkey
+    assert garbage_pubkey_2
+    secret_lock = await wallet1.create_p2pk_lock(
+        garbage_pubkey.serialize().hex(),  # create lock to unspendable pubkey
+        timelock=4,  # timelock
+        tags=[["refund", garbage_pubkey_2.serialize().hex()]],  # refund pubkey
+    )  # sender side
+    _, send_proofs = await wallet1.split_to_send(
+        wallet1.proofs, 8, secret_lock=secret_lock
+    )
+    # receiver side: can't redeem since we used a garbage pubkey
+    await assert_err(wallet2.redeem(send_proofs), "Mint Error: p2pk signature invalid.")
+    await asyncio.sleep(6)
+    # we still can't redeem it because we used garbage_pubkey_2 as a refund pubkey
+    await assert_err(wallet2.redeem(send_proofs), "Mint Error: p2pk signature invalid.")
+
+
+@pytest.mark.asyncio
 async def test_p2sh(wallet1: Wallet, wallet2: Wallet):
     await wallet1.mint(64)
     _ = await wallet1.create_p2sh_address_and_store()  # receiver side

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -273,7 +273,7 @@ async def test_p2pk_receive_with_wrong_private_key(wallet1: Wallet, wallet2: Wal
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     # receiver side: wrong private key
-    settings.nostr_private_key = secrets.token_hex(32)  # wrong private key
+    wallet1.private_key = PrivateKey()  # wrong private key
     await assert_err(wallet1.redeem(send_proofs), "Mint Error: p2pk signature invalid.")
 
 
@@ -291,7 +291,7 @@ async def test_p2pk_short_timelock_receive_with_wrong_private_key(
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     # receiver side: wrong private key
-    settings.nostr_private_key = secrets.token_hex(32)  # wrong private key
+    wallet1.private_key = PrivateKey()  # wrong private key
     await assert_err(wallet1.redeem(send_proofs), "Mint Error: p2pk signature invalid.")
     await asyncio.sleep(6)
     await wallet1.redeem(send_proofs)

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -5,7 +5,7 @@ from typing import List
 import pytest
 import pytest_asyncio
 
-from cashu.core.base import Proof, Secret, SecretKind
+from cashu.core.base import Proof, Secret, SecretKind, Tags
 from cashu.core.crypto.secp import PrivateKey, PublicKey
 from cashu.core.helpers import async_unwrap, sum_proofs
 from cashu.core.migrations import migrate_databases
@@ -307,7 +307,7 @@ async def test_p2pk_timelock_with_refund_pubkey(wallet1: Wallet, wallet2: Wallet
     secret_lock = await wallet1.create_p2pk_lock(
         garbage_pubkey.serialize().hex(),  # create lock to unspendable pubkey
         timelock=4,  # timelock
-        tags=[["refund", pubkey_wallet2]],  # refund pubkey
+        tags=Tags(__root__=[["refund", pubkey_wallet2]]),  # refund pubkey
     )  # sender side
     _, send_proofs = await wallet1.split_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
@@ -331,7 +331,9 @@ async def test_p2pk_timelock_with_wrong_refund_pubkey(wallet1: Wallet, wallet2: 
     secret_lock = await wallet1.create_p2pk_lock(
         garbage_pubkey.serialize().hex(),  # create lock to unspendable pubkey
         timelock=4,  # timelock
-        tags=[["refund", garbage_pubkey_2.serialize().hex()]],  # refund pubkey
+        tags=Tags(
+            __root__=[["refund", garbage_pubkey_2.serialize().hex()]]
+        ),  # refund pubkey
     )  # sender side
     _, send_proofs = await wallet1.split_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -310,23 +310,6 @@ async def test_p2sh(wallet1: Wallet, wallet2: Wallet):
     assert wallet2.balance == 8
 
 
-# @pytest.mark.asyncio
-# async def test_p2sh_short_timelock_receive_with_another_wallet(
-#     wallet1: Wallet, wallet2: Wallet
-# ):
-#     await wallet1.mint(64)
-#     wallet1_address = await wallet1.create_p2sh_address_and_store()  # receiver side
-#     secret_lock = await wallet1.create_p2sh_lock(
-#         wallet1_address, timelock=5
-#     )  # sender side
-#     _, send_proofs = await wallet1.split_to_send(
-#         wallet1.proofs, 8, secret_lock
-#     )  # sender side
-#     await assert_err(wallet2.redeem(send_proofs), "lock not found.")  # wrong receiver
-#     await asyncio.sleep(6)
-#     await wallet2.redeem(send_proofs)  # receiver side
-
-
 @pytest.mark.asyncio
 async def test_p2sh_receive_with_wrong_wallet(wallet1: Wallet, wallet2: Wallet):
     await wallet1.mint(64)

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -246,7 +246,7 @@ async def test_split_with_secret(wallet1: Wallet):
     await wallet1.mint(64)
     secret = f"asdasd_{time.time()}"
     w1_frst_proofs, w1_scnd_proofs = await wallet1.split(
-        wallet1.proofs, 32, scnd_secret=secret
+        wallet1.proofs, 32, secret_lock=secret
     )
     # check if index prefix is in secret
     assert w1_scnd_proofs[0].secret == "0:" + secret


### PR DESCRIPTION
Pay to Public Key (P2PK) allows the sender to lock tokens to a recipient public key. The lock is enforced by the mint and unlocked using a signature of the intended recipient.

## New Secret format
For a normal ecash operation, `Alice` generates a random `secret` that the mint blind-signs. If anyone later presents `secret` and the signature `C` to the mint, the ecash transaction is valid. Naturally, we want to express more complex spending conditions for transactions. That's where P2PK and P2SH spending condition come in. 

To lock tokens to a spending condition, `Alice` needs to generate a special type of `secret`. If the mint encounters a `secret` with a well-known format corresponding to P2PK or P2SH locks, it will demand other conditions to be met in order to validate the transaction. 

### Secret 
The well-known `secret` is as follows:

```json
[
kind <str>, 
  {
    "data": <str>,
    "nonce": <str>,
    "timelock": <int>,
    "tags": [[ "tag_name", "tag_value"],  ... ]
  }
]
```

- `kind` is the kind of lock used, currently: `P2PK` or `P2SH`
- `data` is the lock (pubkey for P2PK, address for P2SH)
- `nonce` is random data (useful if multiple proofs use the same `data` lock)
- `timelock` is the unix time at which the lock will expire (and everyone who knows `secret` can redeem the token)
- `tags` are additional data that are committed to

Here is one example `secret`: 

`["P2PK", {"data": "03e7f4164a8db54e6b6c67bb9c9885d5aec7e24075af8928411478fb9d74aec4ca", "nonce": "dbab884a7b3e427066eb4e0da1776984", "timelock": 1688247220}]`

In the following, we explain how P2PK works and defer documenting P2SH to a later point in time.

## Locking P2PK tokens
`Alice` wants to send `Carol` tokens that only she can unlock. For this, `Carol` provides her public key `<carol_pub>`. `Alice` sends a `POST /split` request to the mint providing `proofs` as inputs and (a subset of) `outputs` as the tokens she wants to send to `Alice`. 

For those tokens, she wants to send to `Carol`, she choses the well-known `secret` format above. She chooses the kind `P2PK`, inserts `<carol_pub>` into the `data` field, and chooses a timelock of 24 hours by settings `timelock` to the current unix timestamp + 24 hours. She proceeds to unblind the signature as she would normally. The resulting tokens are locked by P2PK and only `Carol` can redeem them in the next 24 hours.

## Unlocking P2PK tokens

Spending conditions are enforced by the mint. For `Carol` to unlock proofs in the next `POST /split` request she needs to provide proof that she can indeed unlock the proof (the witness). Note that the witness is revealed to the mint only during the spending of the token, not while locking (since it is blind-signed).

There are two conditions for unlocking a P2PK token that are enforced by the mint.

### Timelock
If the current unix time is later than the timelock specified in the secret, i.e., `now > timelock_int`, the timelock spending path is triggered. There are currently two options to continune. 

- If `secret.tags` contains no `refund` tag, the token is spendable by anyone who knows the secret. 
- If `secret.tags` contains a tag `["refund", <refund_pubkey>`], then the proof can be spent if the owner of `<refund_pubkey>` provided their signature in `proof.p2pksig`. This will typically be the sender's pubkey, in this case `<alice_pub>`.

_Note: This could be extended with a second pubkey of the original sender `Alice`, i.e., a refund pubkey._

### Signature
To redeem the token using the signature path, **`Carol` provides a Schnorr signature on `sha256(secret)`** of each `Proof` she wants to redeem. To do that, Carol redeems the token as usual using the endpoint `POST /split -d <PostSplitRequest>` but she includes a signature `p2pksig` on `sha256(secret)` in every single `Proof` inside the `PostSplitRequest`.

**The `Proof` object is extended by a field `p2pksig`** that is the signature on `sha256(secret)` by `<carol_pub>`. The `p2pksig` is unique to each `Proof` since at least the `nonce` field in `secret` should be unique. A `Proof` is now of the form

```json
{
  "amount": int, 
  "secret": str,
  "C": str,
  "id": str,
  "p2pksig": <signature_hex> <-- new
}
```

### Signature verification
When a token is redeemed (i.e. spent by `Carol`), the mint encounters `secret` and recognizes its well-known format. The mint now demands P2SH validation. For that, the mint first checks whether the time lock is in the past which would validate the spend attempt. If not, the mint parses the `data` field from `secret` which is `<carol_pub>`. The mint then verifies the signature `p2pksig` on `sha256(secret)` is by `<carol_pub>`.

## Implementation details
Nutshell uses `settings.nostr_private_key` to generate the receiving lock (`carol_pub`) and uses it to sign `sha256(secret)`.

_Note: In the current implement, this only works if the nostr private key is stored in hex format. I did not add deserialization of different formats to this part but it's already implemented in the rest of the nostr features._

_Note: the recipient could also be required to sign the entire transaction at once including the outputs but that would require more heavy lifting on the mint side. Please provide feedback._

## Usage
To use this feature in your Nutshell wallet
- add `NOSTR_PRIVATE_KEY` (hex or nsec) to `.env`
- receiver: create a lock with `cashu lock`
- sender: send to this lock with `cashu send <amount> --lock P2PK:<pubkey>`
- receiver: receive with `cashu receive <token>`

## Changes
### Mint
- Accepts secrets up to 512 characters long
- Refactor P2SH code
- Add P2PK
- Add timelocks check to P2PK and P2SH

### Wallet:
- Remove need to specify lock for `cashu receive` (P2SH and P2PK)
- `cashu lock` now shows P2PK key per default and `cashu lock --p2sh` creates P2SH locks
- The recipient can see their public key lock using the command `cashu lock`. 
-  Recipients of either P2SH and P2PK tokens do not have to enter their lock anymore (`cashu receive <token> --lock <address>` is now `cashu receive <token>`) 
- Add new setting `TIMELOCK_DELTA_SECONDS`
- Fix nostr receive

### Todo
- [x] use Schnorr signatures
- [x] decide on which private key to use
- [x] if nostr: parse nsec from settings, not only hex
- [x] find a better way to serialize the `secret`
- [x] then add optional refund pubkey 
- [x] make timelocks optional as well
- [x] add tests for P2PK
- [x] add tests for timelocks for P2PK and P2SH
- [ ] write NUT (add test vectors)
- [x] add `Secret` object that can be serialized instead of this ugly `:`-seperated string
- [x] sign messages only after hashing