### PR TITLE
Add custom error types

### DIFF
--- a/cashu/core/errors.py
+++ b/cashu/core/errors.py
@@ -1,21 +1,83 @@
-from pydantic import BaseModel
+from typing import Optional
 
 
-class CashuError(BaseModel):
+class CashuError(Exception):
     code: int
-    error: str
+    detail: str
+
+    def __init__(self, detail, code=0):
+        super().__init__(detail)
+        self.code = code
+        self.detail = detail
 
 
-class MintException(CashuError):
-    code = 100
-    error = "Mint"
+class NotAllowedError(CashuError):
+    detail = "Not allowed."
+    code = 10000
+
+    def __init__(self, detail: Optional[str] = None, code: Optional[int] = None):
+        super().__init__(detail or self.detail, code=code or self.code)
 
 
-class LightningException(MintException):
-    code = 200
-    error = "Lightning"
+class TransactionError(CashuError):
+    detail = "Transaction error."
+    code = 11000
+
+    def __init__(self, detail: Optional[str] = None, code: Optional[int] = None):
+        super().__init__(detail or self.detail, code=code or self.code)
 
 
-class InvoiceNotPaidException(LightningException):
-    code = 201
-    error = "invoice not paid."
+class TokenAlreadySpentError(TransactionError):
+    detail = "Token already spent."
+    code = 11001
+
+    def __init__(self):
+        super().__init__(self.detail, code=self.code)
+
+
+class SecretTooLongError(CashuError):
+    detail = "Secret too long."
+    code = 11003
+
+    def __init__(self):
+        super().__init__(self.detail, code=self.code)
+
+
+class NoSecretInProofsError(CashuError):
+    detail = "No secret in proofs."
+    code = 11004
+
+    def __init__(self):
+        super().__init__(self.detail, code=self.code)
+
+
+class KeysetError(CashuError):
+    detail = "Keyset error."
+    code = 12000
+
+    def __init__(self, detail: Optional[str] = None, code: Optional[int] = None):
+        super().__init__(detail or self.detail, code=code or self.code)
+
+
+class KeysetNotFoundError(KeysetError):
+    detail = "Keyset not found."
+    code = 12001
+
+    def __init__(self):
+        super().__init__(self.detail, code=self.code)
+
+
+class LightningError(CashuError):
+    detail = "Lightning error."
+    code = 20000
+
+    def __init__(self, detail: Optional[str] = None, code: Optional[int] = None):
+        super().__init__(detail or self.detail, code=code or self.code)
+
+
+class InvoiceNotPaidError(CashuError):
+    detail = "Lightning invoice not paid yet."
+    code = 20001
+
+    def __init__(self):
+        super().__init__(self.detail, code=2001)

--- a/cashu/core/errors.py
+++ b/cashu/core/errors.py
@@ -35,7 +35,7 @@ class TokenAlreadySpentError(TransactionError):
         super().__init__(self.detail, code=self.code)
 
 
-class SecretTooLongError(CashuError):
+class SecretTooLongError(TransactionError):
     detail = "Secret too long."
     code = 11003
 
@@ -43,7 +43,7 @@ class SecretTooLongError(CashuError):
         super().__init__(self.detail, code=self.code)
 
 
-class NoSecretInProofsError(CashuError):
+class NoSecretInProofsError(TransactionError):
     detail = "No secret in proofs."
     code = 11004
 

--- a/cashu/mint/app.py
+++ b/cashu/mint/app.py
@@ -111,18 +111,23 @@ async def catch_exceptions(request: Request, call_next):
     try:
         return await call_next(request)
     except Exception as e:
+        try:
+            err_message = str(e)
+        except:
+            err_message = e.args[0] if e.args else "Unknown error"
+
         if isinstance(e, CashuError):
-            logger.error(f"CashuError: {e}")
+            logger.error(f"CashuError: {err_message}")
             return JSONResponse(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                content={"detail": str(e), "code": e.code},
+                content={"detail": err_message, "code": e.code},
             )
-        logger.error(f"Exception: {e}")
+        logger.error(f"Exception: {err_message}")
         if settings.debug:
             print_exception(*sys.exc_info())
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={"detail": str(e), "code": 0},
+            content={"detail": err_message, "code": 0},
         )
 
 

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -219,8 +219,7 @@ async def split(
     payload: PostSplitRequest,
 ) -> Union[PostSplitResponse, PostSplitResponse_Deprecated]:
     """
-    Requetst a set of tokens with amount "total" to be split into two
-    newly minted sets with amount "split" and "total-split".
+    Requests a set of Proofs to be split into two a new set of BlindedSignatures.
 
     This endpoint is used by Alice to split a set of proofs before making a payment to Carol.
     It is then used by Carol (by setting split=total) to redeem the tokens.
@@ -228,11 +227,6 @@ async def split(
     logger.trace(f"> POST /split: {payload}")
     assert payload.outputs, Exception("no outputs provided.")
 
-    # split_return = await ledger.split(payload.proofs, payload.amount, payload.outputs)
-    # frst_promises, scnd_promises = split_return
-    # resp = PostSplitResponse(fst=frst_promises, snd=scnd_promises)
-    # logger.trace(f"< POST /split: {resp}")
-    # return resp
     promises = await ledger.split(
         proofs=payload.proofs, outputs=payload.outputs, amount=payload.amount
     )

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -61,21 +61,25 @@ async def info() -> GetInfoResponse:
     "/keys",
     name="Mint public keys",
     summary="Get the public keys of the newest mint keyset",
+    response_description="A dictionary of all supported token values of the mint and their associated public key of the current keyset.",
+    response_model=KeysResponse,
 )
-async def keys() -> KeysResponse:
+async def keys():
     """This endpoint returns a dictionary of all supported token values of the mint and their associated public key."""
     logger.trace(f"> GET /keys")
     keyset = ledger.get_keyset()
     keys = KeysResponse.parse_obj(keyset)
-    return keys
+    return keys.__root__
 
 
 @router.get(
     "/keys/{idBase64Urlsafe}",
     name="Keyset public keys",
     summary="Public keys of a specific keyset",
+    response_description="A dictionary of all supported token values of the mint and their associated public key for a specific keyset.",
+    response_model=KeysResponse,
 )
-async def keyset_keys(idBase64Urlsafe: str) -> KeysResponse:
+async def keyset_keys(idBase64Urlsafe: str):
     """
     Get the public keys of the mint from a specific keyset id.
     The id is encoded in idBase64Urlsafe (by a wallet) and is converted back to
@@ -85,7 +89,7 @@ async def keyset_keys(idBase64Urlsafe: str) -> KeysResponse:
     id = idBase64Urlsafe.replace("-", "+").replace("_", "/")
     keyset = ledger.get_keyset(keyset_id=id)
     keys = KeysResponse.parse_obj(keyset)
-    return keys
+    return keys.__root__
 
 
 @router.get(
@@ -93,6 +97,7 @@ async def keyset_keys(idBase64Urlsafe: str) -> KeysResponse:
     name="Active keysets",
     summary="Get all active keyset id of the mind",
     response_model=KeysetsResponse,
+    response_description="A list of all active keyset ids of the mint.",
 )
 async def keysets() -> KeysetsResponse:
     """This endpoint returns a list of keysets that the mint currently supports and will accept tokens from."""
@@ -106,6 +111,7 @@ async def keysets() -> KeysetsResponse:
     name="Request mint",
     summary="Request minting of new tokens",
     response_model=GetMintResponse,
+    response_description="A Lightning invoice to be paid and a hash to request minting of new tokens after payment.",
 )
 async def request_mint(amount: int = 0) -> GetMintResponse:
     """
@@ -131,6 +137,7 @@ async def request_mint(amount: int = 0) -> GetMintResponse:
     name="Mint tokens",
     summary="Mint tokens in exchange for a Bitcoin paymemt that the user has made",
     response_model=PostMintResponse,
+    response_description="A list of blinded signatures that can be used to create proofs.",
 )
 async def mint(
     payload: PostMintRequest,
@@ -160,6 +167,7 @@ async def mint(
     name="Melt tokens",
     summary="Melt tokens for a Bitcoin payment that the mint will make for the user in exchange",
     response_model=GetMeltResponse,
+    response_description="The state of the payment, a preimage as proof of payment, and a list of promises for change.",
 )
 async def melt(payload: PostMeltRequest) -> GetMeltResponse:
     """
@@ -179,6 +187,7 @@ async def melt(payload: PostMeltRequest) -> GetMeltResponse:
     name="Check proof state",
     summary="Check whether a proof is spent already or is pending in a transaction",
     response_model=CheckSpendableResponse,
+    response_description="Two lists of booleans indicating whether the provided proofs are spendable or pending in a transaction respectively.",
 )
 async def check_spendable(
     payload: CheckSpendableRequest,
@@ -196,6 +205,7 @@ async def check_spendable(
     name="Check fees",
     summary="Check fee reserve for a Lightning payment",
     response_model=CheckFeesResponse,
+    response_description="The fees necessary to pay a Lightning invoice.",
 )
 async def check_fees(payload: CheckFeesRequest) -> CheckFeesResponse:
     """
@@ -214,6 +224,7 @@ async def check_fees(payload: CheckFeesRequest) -> CheckFeesResponse:
     name="Split",
     summary="Split proofs at a specified amount",
     response_model=PostSplitResponse,
+    response_description="A list of blinded signatures that can be used to create proofs.",
 )
 async def split(
     payload: PostSplitRequest,
@@ -260,6 +271,7 @@ async def split(
     name="Restore",
     summary="Restores a blinded signature from a secret",
     response_model=PostRestoreResponse,
+    response_description="Two lists with the first being the list of the provided outputs that have an associated blinded signature which is given in the second list.",
 )
 async def restore(payload: PostMintRequest) -> PostRestoreResponse:
     assert payload.outputs, Exception("no outputs provided.")

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -37,7 +37,7 @@ router: APIRouter = APIRouter()
     response_model=GetInfoResponse,
     response_model_exclude_none=True,
 )
-async def info():
+async def info() -> GetInfoResponse:
     logger.trace(f"> GET /info")
     return GetInfoResponse(
         name=settings.mint_info_name,
@@ -88,7 +88,10 @@ async def keyset_keys(idBase64Urlsafe: str) -> KeysResponse:
 
 
 @router.get(
-    "/keysets", name="Active keysets", summary="Get all active keyset id of the mind"
+    "/keysets",
+    name="Active keysets",
+    summary="Get all active keyset id of the mind",
+    response_model=KeysetsResponse,
 )
 async def keysets() -> KeysetsResponse:
     """This endpoint returns a list of keysets that the mint currently supports and will accept tokens from."""
@@ -97,7 +100,12 @@ async def keysets() -> KeysetsResponse:
     return keysets
 
 
-@router.get("/mint", name="Request mint", summary="Request minting of new tokens")
+@router.get(
+    "/mint",
+    name="Request mint",
+    summary="Request minting of new tokens",
+    response_model=GetMintResponse,
+)
 async def request_mint(amount: int = 0) -> GetMintResponse:
     """
     Request minting of new tokens. The mint responds with a Lightning invoice.
@@ -121,6 +129,7 @@ async def request_mint(amount: int = 0) -> GetMintResponse:
     "/mint",
     name="Mint tokens",
     summary="Mint tokens in exchange for a Bitcoin paymemt that the user has made",
+    response_model=PostMintResponse,
 )
 async def mint(
     payload: PostMintRequest,
@@ -149,6 +158,7 @@ async def mint(
     "/melt",
     name="Melt tokens",
     summary="Melt tokens for a Bitcoin payment that the mint will make for the user in exchange",
+    response_model=GetMeltResponse,
 )
 async def melt(payload: PostMeltRequest) -> GetMeltResponse:
     """
@@ -167,6 +177,7 @@ async def melt(payload: PostMeltRequest) -> GetMeltResponse:
     "/check",
     name="Check proof state",
     summary="Check whether a proof is spent already or is pending in a transaction",
+    response_model=CheckSpendableResponse,
 )
 async def check_spendable(
     payload: CheckSpendableRequest,
@@ -183,6 +194,7 @@ async def check_spendable(
     "/checkfees",
     name="Check fees",
     summary="Check fee reserve for a Lightning payment",
+    response_model=CheckFeesResponse,
 )
 async def check_fees(payload: CheckFeesRequest) -> CheckFeesResponse:
     """
@@ -196,7 +208,12 @@ async def check_fees(payload: CheckFeesRequest) -> CheckFeesResponse:
     return CheckFeesResponse(fee=fees_sat)
 
 
-@router.post("/split", name="Split", summary="Split proofs at a specified amount")
+@router.post(
+    "/split",
+    name="Split",
+    summary="Split proofs at a specified amount",
+    response_model=PostSplitResponse,
+)
 async def split(
     payload: PostSplitRequest,
 ) -> PostSplitResponse:
@@ -218,7 +235,10 @@ async def split(
 
 
 @router.post(
-    "/restore", name="Restore", summary="Restores a blinded signature from a secret"
+    "/restore",
+    name="Restore",
+    summary="Restores a blinded signature from a secret",
+    response_model=PostRestoreResponse,
 )
 async def restore(payload: PostMintRequest) -> PostRestoreResponse:
     assert payload.outputs, Exception("no outputs provided.")

--- a/cashu/wallet/api/app.py
+++ b/cashu/wallet/api/app.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
+from loguru import logger
 
 from ...core.settings import settings
 from .router import router
@@ -28,9 +29,9 @@ app = create_app()
 @app.middleware("http")
 async def catch_exceptions(request: Request, call_next):
     try:
-        response = await call_next(request)
-        return response
+        return await call_next(request)
     except Exception as e:
+        logger.error(f"Exception: {e}")
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST, content={"detail": str(e)}
         )

--- a/tests/test_mint_api.py
+++ b/tests/test_mint_api.py
@@ -49,13 +49,13 @@ async def test_api_keyset_keys(ledger):
 @pytest.mark.asyncio
 async def test_api_mint_validation(ledger):
     response = requests.get(f"{BASE_URL}/mint?amount=-21")
-    assert "error" in response.json()
+    assert "detail" in response.json()
     response = requests.get(f"{BASE_URL}/mint?amount=0")
-    assert "error" in response.json()
+    assert "detail" in response.json()
     response = requests.get(f"{BASE_URL}/mint?amount=2100000000000001")
-    assert "error" in response.json()
+    assert "detail" in response.json()
     response = requests.get(f"{BASE_URL}/mint?amount=1")
-    assert "error" not in response.json()
+    assert "detail" not in response.json()
 
 
 @pytest.mark.asyncio

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -2,7 +2,7 @@ import asyncio
 import shutil
 import time
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Union
 
 import pytest
 import pytest_asyncio
@@ -10,6 +10,18 @@ from mnemonic import Mnemonic
 
 from cashu.core.base import Proof, Secret, SecretKind, Tags
 from cashu.core.crypto.secp import PrivateKey, PublicKey
+from cashu.core.errors import (
+    CashuError,
+    InvoiceNotPaidError,
+    KeysetError,
+    KeysetNotFoundError,
+    LightningError,
+    NoSecretInProofsError,
+    NotAllowedError,
+    SecretTooLongError,
+    TokenAlreadySpentError,
+    TransactionError,
+)
 from cashu.core.helpers import async_unwrap, sum_proofs
 from cashu.core.migrations import migrate_databases
 from cashu.core.settings import settings
@@ -20,13 +32,20 @@ from cashu.wallet.wallet import Wallet as Wallet2
 from tests.conftest import SERVER_ENDPOINT, mint
 
 
-async def assert_err(f, msg):
+async def assert_err(f, msg: Union[str, CashuError]):
     """Compute f() and expect an error message 'msg'."""
     try:
         await f
     except Exception as exc:
-        if str(exc.args[0]) != msg:
-            raise Exception(f"Expected error: {msg}, got: {exc.args[0]}")
+        error_message: str = str(exc.args[0])
+        if isinstance(msg, CashuError):
+            if msg.detail not in error_message:
+                raise Exception(
+                    f"CashuError. Expected error: {msg.detail}, got: {error_message}"
+                )
+            return
+        if msg not in error_message:
+            raise Exception(f"Expected error: {msg}, got: {error_message}")
         return
     raise Exception(f"Expected error: {msg}, got no error")
 
@@ -119,7 +138,7 @@ async def test_get_info(wallet1: Wallet):
 async def test_get_nonexistent_keyset(wallet1: Wallet):
     await assert_err(
         wallet1._get_keys_of_keyset(wallet1.url, "nonexistent"),
-        "Mint Error: keyset does not exist",
+        KeysetNotFoundError(),
     )
 
 
@@ -220,7 +239,7 @@ async def test_double_spend(wallet1: Wallet):
     await wallet1.split(wallet1.proofs, 20)
     await assert_err(
         wallet1.split(doublespend, 20),
-        f"Mint Error: tokens already spent. Secret: {doublespend[0]['secret']}",
+        f"Mint Error: Token already spent.",
     )
     assert wallet1.balance == 64
     assert wallet1.available_balance == 64

--- a/tests/test_wallet_p2pk.py
+++ b/tests/test_wallet_p2pk.py
@@ -23,7 +23,7 @@ async def assert_err(f, msg):
     try:
         await f
     except Exception as exc:
-        if str(exc.args[0]) != msg:
+        if msg not in str(exc.args[0]):
             raise Exception(f"Expected error: {msg}, got: {exc.args[0]}")
         return
     raise Exception(f"Expected error: {msg}, got no error")


### PR DESCRIPTION
Main changes:

- `app.py`: mint now has a FastApi middleware that catches all exceptions and returns proper HTTP errors with status codes (instead of always returning code 200 with an error JSON)
- `router.py` now just let's the error bubble up to the middleware instead of returning the error
- `errors.py`: Start to define error types with error codes.
- Errors as JSON example: `{"detail":"Keyset not found.","code":12001}`
- `ledger.py`: raise new custom error types.
- `wallet.py`: `raise_on_error` for new error types.
