### PR TITLE
load the proofs or we get a zero balance

### DIFF
--- a/cashu/wallet/api/router.py
+++ b/cashu/wallet/api/router.py
@@ -88,6 +88,7 @@ async def pay(
 
     global wallet
     wallet = await mint_wallet(mint)
+    await wallet.load_proofs(reload=True)
 
     total_amount, fee_reserve_sat = await wallet.get_pay_amount_with_fees(invoice)
     assert total_amount > 0, "amount has to be larger than zero."


### PR DESCRIPTION
Call load_proofs to enable a non-zero balance to be detected in the mint wallet to assess whehter or not the payment can be made.


(cherry picked from commit 0e058fa69f53689c7d9d37f02b4f5a62c58f03e7)